### PR TITLE
feat: Add JupyterLab integration with optional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ This repository requires Docker and Docker Compose to be installed on your syste
 
 For detailed usage instructions and endpoint descriptions, refer to the API swagger documentation, accessible once the server is running at `/docs`.
 
+## Optional Integrations
+
+The POP API provides core functionalities for managing and interacting with POP resources. These core features include:
+
+- Managing and handling data within an internal CKAN instance.
+- Searching for data across the internal CKAN instance and external CKAN instances.
+- Authentication and authorization via Keycloak.
+
+In addition to these core capabilities, the POP API also supports optional configurations to connect with other services being developed in SciDx. These integrations are designed to enhance functionality but are not required for the basic operation of the API:
+
+1. **Kafka Integration**:  
+   Enables the POP API to connect with a Kafka broker for real-time data streaming. To configure this integration, use the `.env_kafka` file located in the `env_variables` directory.
+
+2. **JupyterLab Integration**:  
+   Adds a link to a JupyterLab instance on the main page of the API, enabling users to access it directly. To enable this integration, configure the following variables in the `env_variables/.env_swagger` file:
+   - `USE_JUPYTERLAB`: Set to `True` to enable the integration (default: `False`).
+   - `JUPYTER_URL`: Specify the URL of the JupyterLab instance to be linked.
+
+These optional features allow the POP API to seamlessly integrate with other components in SciDx, providing extended capabilities for specialized use cases.
+
 
 ## Running Tests
 

--- a/api/config/__init__.py
+++ b/api/config/__init__.py
@@ -1,3 +1,5 @@
+# api/config/__init__.py
+
 from .ckan_settings import ckan_settings  # noqa: F401
 from .swagger_settings import swagger_settings  # noqa: F401
 from .keycloak_settings import keycloak_settings  # noqa: F401

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     swagger_version: str = "0.3.0"
     public: bool = True
     use_jupyterlab: bool = False
-    jupyter_url: str = "http://localhost:8888"
+    jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"
 
     model_config = {
         "env_file": "./env_variables/.env_swagger",

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -1,3 +1,5 @@
+# api/config/swagger_settings.py
+
 from pydantic_settings import BaseSettings
 
 

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     swagger_description: str = "This is the API documentation."
     swagger_version: str = "0.3.0"
     public: bool = True
+    use_jupyterlab: bool = False
+    jupyter_url: str = "http://localhost:8888"
 
     model_config = {
         "env_file": "./env_variables/.env_swagger",

--- a/api/routes/default_routes/get.py
+++ b/api/routes/default_routes/get.py
@@ -1,3 +1,5 @@
+# api/routes/default_routes/get.py
+
 from fastapi import APIRouter, Request
 from api.services import default_services
 

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -43,6 +43,10 @@ def index(request: Request):
         "kafka_port": kafka_settings.kafka_port,
         "kafka_connection": kafka_settings.kafka_connection,
     }
+    
+    # Add JupyterLab settings to context
+    use_jupyterlab = swagger_settings.use_jupyterlab
+    jupyter_url = swagger_settings.jupyter_url if use_jupyterlab else None
 
     return templates.TemplateResponse(
         request=request,

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -43,7 +43,7 @@ def index(request: Request):
         "kafka_port": kafka_settings.kafka_port,
         "kafka_connection": kafka_settings.kafka_connection,
     }
-    
+
     # Add JupyterLab settings to context
     use_jupyterlab = swagger_settings.use_jupyterlab
     jupyter_url = swagger_settings.jupyter_url if use_jupyterlab else None

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -56,6 +56,8 @@ def index(request: Request):
             "version": swagger_settings.swagger_version,
             "docs_url": f"{request.base_url}docs",
             "status": status,
-            "kafka_info": kafka_info
+            "kafka_info": kafka_info,
+            "use_jupyterlab": use_jupyterlab,
+            "jupyter_url": jupyter_url
         }
     )

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -20,7 +20,7 @@
                 <p class="lead text-success">
                     <i class="fas fa-check-circle"></i> - CKAN is active
                 </p>
-                <p class="lead text-danger">
+                <p class="lead text-danger" style="height: 49px; transform: translate(0px, -19px);">
                     <i class="fas fa-times-circle"></i> - Keycloak is not reachable
                 </p>
 
@@ -28,7 +28,7 @@
                 <p class="lead text-success">
                     <i class="fas fa-check-circle"></i> - Keycloak is active
                 </p>
-                <p class="lead text-danger">
+                <p class="lead text-danger" style="height: 49px; transform: translate(0px, -19px);">
                     <i class="fas fa-times-circle"></i> - CKAN is not reachable
                 </p>
         </ul>
@@ -45,23 +45,34 @@
     </div>
 </div>
 
-<!-- Kafka Details Section -->
-{% if kafka_info.kafka_connection %}
+<!-- Extras Section -->
 <div class="row mt-4 d-flex justify-content-center">
+    <!-- Kafka -->
+    {% if kafka_info.kafka_connection %}
     <div class="card card-square shadow-sm">
         <div class="card-header card-header-custom">
             <h5 class="card-title-custom">Kafka Connection</h5>
         </div>
         <div class="card-body card-body-custom">
             <p style="font-size: 15px;"><strong>Host:</strong> {{ kafka_info.kafka_host }}</p>
-            <p style="font-size: 15px;"><strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
+            <p style="font-size: 15px font-size: 15px; height: 21.5px; transform: translate(0px, -14px);"><strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
         </div>
     </div>
+    {% endif %}
+    <!-- Kafka -->
+    {% if use_jupyterlab %}
+    <div class="card card-square shadow-sm">
+        <div class="card-header card-header-custom">
+            <h5 class="card-title-custom">JupyterLab</h5>
+        </div>
+        <div class="card-body card-body-custom">
+            <a href="{{ jupyter_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer" style="height: 60px; transform: translate(0px, -9px);">
+                Access JupyterLab
+            </a>
+        </div>
+    </div>
+    {% endif %}
 </div>
-{% endif %}
-
-
-
 
 
 {% endblock %}

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -1,3 +1,5 @@
+<!-- api/templates/index.html -->
+
 {% extends "base.html" %}
 
 {% block title %}{{ title }}{% endblock %}

--- a/env_variables/example.env_swagger
+++ b/env_variables/example.env_swagger
@@ -17,4 +17,4 @@ PUBLIC=True
 # Enable or disable JupyterLab integration
 USE_JUPYTERLAB=False
 # URL to access JupyterLab (used only if USE_JUPYTERLAB=True)
-JUPYTER_URL=http://localhost:8888
+JUPYTER_URL=https://jupyter.org/try-jupyter/lab/

--- a/env_variables/example.env_swagger
+++ b/env_variables/example.env_swagger
@@ -13,3 +13,8 @@ SWAGGER_VERSION=0.3.0
 
 # Set to 'True' if the POP is publicly accessible; 'False' if it's private
 PUBLIC=True
+
+# Enable or disable JupyterLab integration
+USE_JUPYTERLAB=False
+# URL to access JupyterLab (used only if USE_JUPYTERLAB=True)
+JUPYTER_URL=http://localhost:8888


### PR DESCRIPTION
This Pull Request resolves the issue by introducing an optional JupyterLab integration into the POP API. The following changes were made:

- Added new environment variables in `env_variables/.env_swagger`:
  - `USE_JUPYTERLAB`: Enables or disables the JupyterLab integration (`True`/`False`).
  - `JUPYTER_URL`: Specifies the URL of the JupyterLab instance.

- Updated `swagger_settings.py` to load and manage the new environment variables.

- Modified the `/` endpoint to:
  - Check if JupyterLab integration is enabled.
  - Pass `use_jupyterlab` and `jupyter_url` to the template context.

- Updated `index.html` to display a styled link to JupyterLab when integration is enabled.

- Added documentation in the README under the **Optional Integrations** section to describe the new functionality.
