### PR TITLE
fix: Improve error handling for duplicate dataset registration

### DIFF
--- a/api/routes/register_routes/post_kafka.py
+++ b/api/routes/register_routes/post_kafka.py
@@ -121,15 +121,15 @@ async def create_kafka_datasource(
         )
         return {"id": dataset_id}
     except Exception as e:
-            if ("That URL is already in use" in str(e) or
-                "That name is already in use" in str(e)):
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail={
-                        "error": "Duplicate Dataset",
-                        "detail": "A dataset with the given name or URL "
-                        "already exists."
-                    }
-                )
+        if "That URL is already in use" in str(e) \
+           or "That name is already in use" in str(e):
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "Duplicate Dataset",
+                    "detail": "A dataset with the given name or URL "
+                    "already exists."
+                }
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/api/routes/register_routes/post_kafka.py
+++ b/api/routes/register_routes/post_kafka.py
@@ -1,3 +1,4 @@
+# api/routes/register_routes/post_kafka.py
 from fastapi import APIRouter, HTTPException, status, Depends
 from api.services import kafka_services
 from api.models.request_kafka_model import KafkaDataSourceRequest
@@ -120,4 +121,15 @@ async def create_kafka_datasource(
         )
         return {"id": dataset_id}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+            if ("That URL is already in use" in str(e) or
+                "That name is already in use" in str(e)):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "error": "Duplicate Dataset",
+                        "detail": "A dataset with the given name or URL "
+                        "already exists."
+                    }
+                )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/api/routes/register_routes/post_kafka.py
+++ b/api/routes/register_routes/post_kafka.py
@@ -66,6 +66,20 @@ router = APIRouter()
                 }
             }
         },
+        409: {
+            "description": "Conflict - Duplicate dataset",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": {
+                            "error": "Duplicate Dataset",
+                            "detail": "A dataset with the given name or URL "
+                            "already exists."
+                        }
+                    }
+                }
+            }
+        },
         400: {
             "description": "Bad Request",
             "content": {

--- a/api/services/kafka_services/add_kafka.py
+++ b/api/services/kafka_services/add_kafka.py
@@ -1,3 +1,4 @@
+# api/services/kafka_services/add_kafka.py
 import json
 from api.config.ckan_settings import ckan_settings
 

--- a/tests/test_create_kafka_datasource.py
+++ b/tests/test_create_kafka_datasource.py
@@ -1,3 +1,4 @@
+# tests/test_create_kafka_datasource.py
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 from api.main import app

--- a/tests/test_create_kafka_datasource.py
+++ b/tests/test_create_kafka_datasource.py
@@ -132,3 +132,37 @@ def test_create_kafka_datasource_validation_error():
 
     # Clean up the override
     app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_create_kafka_datasource_duplicate_error():
+    # Mock del servicio para simular un error de duplicidad
+    with patch("api.services.kafka_services.add_kafka") as mock_add_kafka:
+        mock_add_kafka.side_effect = Exception(
+            '{"name": ["That name is already in use."]}'
+        )
+
+        # Mock del usuario autenticado
+        def mock_get_current_user():
+            return {"user": "test_user"}
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+
+        data = {
+            "dataset_name": "duplicate_name",
+            "dataset_title": "Duplicate Name",
+            "owner_org": "test_org",
+            "kafka_topic": "test_topic",
+            "kafka_host": "localhost",
+            "kafka_port": "9092",
+            "dataset_description": "Test dataset"
+        }
+
+        # Ejecutamos el endpoint y verificamos la respuesta
+        response = client.post("/kafka", json=data)
+        assert response.status_code == 409
+        assert response.json() == {
+            "detail": {
+                "error": "Duplicate Dataset",
+                "detail": "A dataset with the given name or URL "
+                "already exists."
+            }
+        }


### PR DESCRIPTION
This pull request addresses the issue of duplicate dataset registration in the Kafka endpoint. The following changes have been implemented:

1. **Enhanced Error Handling**: 
   - Added logic to handle cases where a dataset with the same name or URL already exists.
   - The API now returns a `409 Conflict` response with a clear message indicating the dataset duplication.

2. **Tests for Duplicity**:
   - Created a test to verify that duplicate dataset registration returns the expected `409 Conflict` response.
   - Confirmed existing tests still pass.

3. **Updated Documentation**:
   - The Swagger documentation now includes details about the `409 Conflict` response and an example message for duplicate datasets.