### PR TITLE
feat: make local CKAN optional, refine dashboard styling, and conditionally skip tests

### DIFF
--- a/api/config/ckan_settings.py
+++ b/api/config/ckan_settings.py
@@ -5,6 +5,7 @@ from ckanapi import RemoteCKAN
 
 
 class Settings(BaseSettings):
+    ckan_local_enabled: bool = True
     ckan_url: str = "http://localhost:5000"
     ckan_api_key: str = "your-api-key"
     ckan_global_url: str = "http://localhost:5000"

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.3.0"
+    swagger_version: str = "0.4.0"
     public: bool = True
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"

--- a/api/main.py
+++ b/api/main.py
@@ -8,7 +8,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.security import OAuth2PasswordBearer
 
 import api.routes as routes
-from api.config import swagger_settings
+from api.config import swagger_settings, ckan_settings
 
 
 app = FastAPI(
@@ -30,10 +30,13 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 app.include_router(routes.default_router, include_in_schema=False)
-app.include_router(routes.register_router, tags=["Registration"])
+if ckan_settings.ckan_local_enabled:
+    app.include_router(routes.register_router, tags=["Registration"])
 app.include_router(routes.search_router, tags=["Search"])
-app.include_router(routes.update_router, tags=["Update"])
-app.include_router(routes.delete_router, tags=["Delete"])
+if ckan_settings.ckan_local_enabled:
+    app.include_router(routes.update_router, tags=["Update"])
+if ckan_settings.ckan_local_enabled:
+    app.include_router(routes.delete_router, tags=["Delete"])
 app.include_router(routes.token_router, tags=["Token"])
 app.include_router(routes.status_router, prefix="/status", tags=["Status"])
 

--- a/api/routes/status_routes/get.py
+++ b/api/routes/status_routes/get.py
@@ -1,9 +1,7 @@
 # api/routes/status_routes/get.py
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from api.services import status_services
-from api.services.keycloak_services.introspect_user_token import \
-    get_client_token
 
 
 router = APIRouter()
@@ -11,7 +9,7 @@ router = APIRouter()
 
 @router.get(
     "/",
-    response_model=str,
+    response_model=dict,
     summary="Check system status",
     description=(
         "Check if the CKAN and Keycloak servers are active "
@@ -32,30 +30,6 @@ async def get_status():
         If there is an error connecting to CKAN or Keycloak, an HTTPException
         is raised with a detailed message.
     """
-    try:
-        # Check CKAN status
-        ckan_is_active = status_services.check_ckan_status()
+    return_dict = status_services.get_status()
 
-        # Check Keycloak status by attempting to get a client token
-        try:
-            get_client_token()
-            keycloak_is_active = True
-        except Exception:
-            keycloak_is_active = False
-
-        # Return appropriate message based on both statuses
-        if ckan_is_active and keycloak_is_active:
-            return "CKAN and Keycloak are active and reachable."
-        else:
-            if ckan_is_active and not keycloak_is_active:
-                raise HTTPException(
-                    status_code=503, detail="Keycloak is not reachable.")
-            elif keycloak_is_active:
-                raise HTTPException(
-                    status_code=503, detail="CKAN is not reachable.")
-            else:
-                raise HTTPException(
-                    status_code=503,
-                    detail="CKAN and Keycloak are not reachable.")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return return_dict

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -6,8 +6,6 @@ from fastapi.templating import Jinja2Templates
 from api.config import swagger_settings
 from api.config.kafka_settings import kafka_settings
 from api.services import status_services
-from api.services.keycloak_services.introspect_user_token import \
-    get_client_token
 
 
 def index(request: Request):

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -13,29 +13,7 @@ from api.services.keycloak_services.introspect_user_token import \
 def index(request: Request):
     templates = Jinja2Templates(directory="api/templates")
 
-    # Check CKAN status
-    try:
-        ckan_is_active = status_services.check_ckan_status()
-
-        # Check Keycloak status by attempting to get a client token
-        try:
-            get_client_token()  # If this succeeds, Keycloak is reachable
-            keycloak_is_active = True
-        except Exception:
-            keycloak_is_active = False
-
-        # Determine the status message based on CKAN and Keycloak statuses
-        if ckan_is_active and keycloak_is_active:
-            status = "CKAN and Keycloak are active and reachable."
-        else:
-            if ckan_is_active and not keycloak_is_active:
-                status = "CKAN is active, but Keycloak is not reachable."
-            elif keycloak_is_active:
-                status = "Keycloak is active, but CKAN is not reachable."
-            else:
-                status = "CKAN and Keycloak are not reachable."
-    except Exception:
-        status = "CKAN and Keycloak are not reachable."
+    status = status_services.get_status()
 
     # Add Kafka information
     kafka_info = {

--- a/api/services/status_services/__init__.py
+++ b/api/services/status_services/__init__.py
@@ -1,1 +1,2 @@
 from .check_ckan_status import check_ckan_status  # noqa: F401
+from .check_api_status import get_status  # noqa: F401

--- a/api/services/status_services/check_api_status.py
+++ b/api/services/status_services/check_api_status.py
@@ -5,10 +5,11 @@ from api.services import status_services
 from api.services.keycloak_services.introspect_user_token import \
     get_client_token
 
+
 def get_status():
     """
     Checks if local/global CKAN and Keycloak are active and reachable.
-    
+
     Returns
     -------
     dict
@@ -22,7 +23,7 @@ def get_status():
 
     Note
     ----
-    If local CKAN is disabled, 'ckan_is_active_local' will be None by default 
+    If local CKAN is disabled, 'ckan_is_active_local' will be None by default
     and no check will be performed for local CKAN.
     """
     status_dict = {

--- a/api/services/status_services/check_api_status.py
+++ b/api/services/status_services/check_api_status.py
@@ -1,0 +1,58 @@
+# api/services/status_services/check_api_status.py
+
+from api.config.ckan_settings import ckan_settings
+from api.services import status_services
+from api.services.keycloak_services.introspect_user_token import \
+    get_client_token
+
+def get_status():
+    """
+    Checks if local/global CKAN and Keycloak are active and reachable.
+    
+    Returns
+    -------
+    dict
+        A dictionary with the following keys:
+          - ckan_local_enabled (bool): Whether local CKAN is enabled in
+          settings.
+          - ckan_is_active_local (bool or None): Whether local CKAN is
+          reachable (if enabled).
+          - ckan_is_active_global (bool): Whether global CKAN is reachable.
+          - keycloak_is_active (bool): Whether Keycloak is active.
+
+    Note
+    ----
+    If local CKAN is disabled, 'ckan_is_active_local' will be None by default 
+    and no check will be performed for local CKAN.
+    """
+    status_dict = {
+        "ckan_local_enabled": ckan_settings.ckan_local_enabled,
+        "ckan_is_active_local": None,
+        "ckan_is_active_global": False,
+        "keycloak_is_active": False
+    }
+
+    # 1. Check local CKAN if enabled
+    if ckan_settings.ckan_local_enabled:
+        try:
+            # Defaults to checking local CKAN if no arguments are passed
+            status_dict["ckan_is_active_local"] = \
+                status_services.check_ckan_status()
+        except Exception:
+            status_dict["ckan_is_active_local"] = False
+
+    # 2. Check global CKAN
+    try:
+        status_dict["ckan_is_active_global"] = \
+            status_services.check_ckan_status(local=False)
+    except Exception:
+        status_dict["ckan_is_active_global"] = False
+
+    # 3. Check Keycloak status
+    try:
+        get_client_token()
+        status_dict["keycloak_is_active"] = True
+    except Exception:
+        status_dict["keycloak_is_active"] = False
+
+    return status_dict

--- a/api/services/status_services/check_ckan_status.py
+++ b/api/services/status_services/check_ckan_status.py
@@ -2,9 +2,15 @@ from ckanapi import NotFound
 from api.config.ckan_settings import ckan_settings
 
 
-def check_ckan_status() -> bool:
+def check_ckan_status(local=True) -> bool:
     """
     Check if CKAN is active and reachable.
+
+    Parameters
+    ----------
+    local : bool, optional
+        If True, check the local CKAN instance. If False, check the global CKAN
+        instance. The default is True.
 
     Returns
     -------
@@ -16,7 +22,10 @@ def check_ckan_status() -> bool:
     Exception
         If there is an error connecting to CKAN.
     """
-    ckan = ckan_settings.ckan
+    if local:
+        ckan = ckan_settings.ckan
+    else:
+        ckan = ckan_settings.ckan_global
 
     try:
         # Make a request to the status endpoint of CKAN

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -69,18 +69,24 @@
       </div>
     </div>
 
-    <!-- Kafka -->
-    {% if kafka_info.kafka_connection %}
+    <!-- Kafka in a card with a similar style -->
     <div class="card card-square shadow-sm mx-2 my-2">
-        <div class="card-header card-header-custom">
-            <h5 class="card-title-custom">Kafka</h5>
-        </div>
-        <div class="card-body card-body-custom">
-            <p><strong>Host:</strong> {{ kafka_info.kafka_host }}</br>
-               <strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
-        </div>
+    <div class="card-header card-header-custom">
+        <h5 class="card-title-custom">Kafka</h5>
     </div>
-    {% endif %}
+    <div class="card-body card-body-custom">
+        {% if kafka_info.kafka_connection %}
+        <p>
+            <strong>Host:</strong> {{ kafka_info.kafka_host }}<br/>
+            <strong>Port:</strong> {{ kafka_info.kafka_port }}
+        </p>
+        {% else %}
+        <p class="text-muted">
+            <strong>Status:</strong> Disabled
+        </p>
+        {% endif %}
+    </div>
+    </div>
 
     <!-- JupyterLab -->
     {% if use_jupyterlab %}

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -89,6 +89,23 @@
     </div>
 
     <!-- JupyterLab -->
+    <div class="card card-square shadow-sm mx-2 my-2">
+        <div class="card-header card-header-custom">
+            <h5 class="card-title-custom">JupyterLab</h5>
+        </div>
+        <div class="card-body card-body-custom">
+            {% if use_jupyterlab %}
+            <a href="{{ jupyter_url }}" class="btn btn-primary"
+               target="_blank" rel="noopener noreferrer">
+                Access
+            </a>
+            {% else %}
+            <p class="text-muted">
+                <strong>Status:</strong> Disabled
+            </p>
+            {% endif %}
+        </div>
+    </div>
     {% if use_jupyterlab %}
     <div class="card card-square shadow-sm mx-2 my-2">
         <div class="card-header card-header-custom">

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -10,74 +10,88 @@
         <h1>{{ title }} v{{ version }}</h1>
         <hr />
 
-        <!-- Local CKAN -->
-        {% if status.ckan_local_enabled %}
-            <p class="text-primary">
-                <strong>Local CKAN:</strong> Enabled
-            </p>
-            {% if status.ckan_is_active_local %}
-                <p class="lead text-success">
-                    <i class="fas fa-check-circle"></i> Local CKAN is active and reachable
-                </p>
-            {% else %}
-                <p class="lead text-danger">
-                    <i class="fas fa-times-circle"></i> Local CKAN is not reachable
-                </p>
-            {% endif %}
-        {% else %}
-            <p class="text-muted">
-                <strong>Local CKAN:</strong> Disabled
-            </p>
-        {% endif %}
-
-        <!-- Global CKAN -->
-        {% if status.ckan_is_active_global %}
-            <p class="lead text-success">
-                <i class="fas fa-check-circle"></i> Global CKAN is active and reachable
-            </p>
-        {% else %}
-            <p class="lead text-danger">
-                <i class="fas fa-times-circle"></i> Global CKAN is not reachable
-            </p>
-        {% endif %}
-
         <!-- Keycloak -->
         {% if status.keycloak_is_active %}
-            <p class="lead text-success">
-                <i class="fas fa-check-circle"></i> Keycloak is active and reachable
+            <p class="text-primary text-success">
+                <strong>Keycloak:</strong> Reachable
             </p>
         {% else %}
-            <p class="lead text-danger">
-                <i class="fas fa-times-circle"></i> Keycloak is not reachable
+            <p class="text-primary text-danger">
+                <strong>Keycloak:</strong> Not reachable
             </p>
         {% endif %}
+
+        <!-- Remote CKAN -->
+        {% if status.ckan_is_active_global %}
+            <p class="text-primary text-success">
+                <strong>Remote CKAN:</strong> Reachable
+            </p>
+        {% else %}
+        <p class="text-primary text-danger">
+            <strong>Remote CKAN:</strong> Not reachable
+        </p>
+        {% endif %}
+
     </div>
 </div>
 
 <!-- Extras Section -->
 <div class="row mt-4 d-flex justify-content-center">
+    <!-- Local CKAN in a card -->
+    <div class="card card-square shadow-sm mx-2 my-2">
+      <div class="card-header card-header-custom">
+          <h5 class="card-title-custom">Local CKAN</h5>
+      </div>
+      <div class="card-body card-body-custom">
+          {% if status.ckan_local_enabled %}
+              {% if status.ckan_is_active_local is not none %}
+                  {% if status.ckan_is_active_local %}
+                      <p class="text-primary text-success">
+                          <strong>Status:</strong> Reachable
+                      </p>
+                  {% else %}
+                      <p class="text-primary text-danger">
+                          <strong>Status:</strong> Not reachable
+                      </p>
+                  {% endif %}
+              {% else %}
+                  <!-- If you do not set 'ckan_is_active_local' when disabled, 
+                       this block might remain unused. -->
+                  <p class="text-muted">
+                      <strong>Status:</strong> Not reachable
+                  </p>
+              {% endif %}
+          {% else %}
+              <p class="text-muted">
+                  <strong>Status:</strong> Disabled
+              </p>
+          {% endif %}
+      </div>
+    </div>
+
     <!-- Kafka -->
     {% if kafka_info.kafka_connection %}
-    <div class="card card-square shadow-sm mx-2">
+    <div class="card card-square shadow-sm mx-2 my-2">
         <div class="card-header card-header-custom">
-            <h5 class="card-title-custom">Kafka Connection</h5>
+            <h5 class="card-title-custom">Kafka</h5>
         </div>
         <div class="card-body card-body-custom">
-            <p><strong>Host:</strong> {{ kafka_info.kafka_host }}</p>
-            <p><strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
+            <p><strong>Host:</strong> {{ kafka_info.kafka_host }}</br>
+               <strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
         </div>
     </div>
     {% endif %}
 
     <!-- JupyterLab -->
     {% if use_jupyterlab %}
-    <div class="card card-square shadow-sm mx-2">
+    <div class="card card-square shadow-sm mx-2 my-2">
         <div class="card-header card-header-custom">
             <h5 class="card-title-custom">JupyterLab</h5>
         </div>
         <div class="card-body card-body-custom">
-            <a href="{{ jupyter_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
-                Access JupyterLab
+            <a href="{{ jupyter_url }}" class="btn btn-primary"
+               target="_blank" rel="noopener noreferrer">
+                Access
             </a>
         </div>
     </div>

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -5,41 +5,50 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<!-- Dashboard Header -->
 <div class="row">
     <div class="col-md-12">
         <h1>{{ title }} v{{ version }}</h1>
-        
-        {% if status == "CKAN and Keycloak are active and reachable." %}
-            <p class="lead text-success">
-                <i class="fas fa-check-circle"></i> The system is operating correctly without any issues
-            </p>
-        
-        <ul class="list-unstyled compact-list">
-            {% elif status == "CKAN is active, but Keycloak is not reachable." %}
-                <p class="lead text-success">
-                    <i class="fas fa-check-circle"></i> - CKAN is active
-                </p>
-                <p class="lead text-danger" style="height: 49px; transform: translate(0px, -19px);">
-                    <i class="fas fa-times-circle"></i> - Keycloak is not reachable
-                </p>
+        <hr />
 
-            {% elif status == "Keycloak is active, but CKAN is not reachable." %}
-                <p class="lead text-success">
-                    <i class="fas fa-check-circle"></i> - Keycloak is active
-                </p>
-                <p class="lead text-danger" style="height: 49px; transform: translate(0px, -19px);">
-                    <i class="fas fa-times-circle"></i> - CKAN is not reachable
-                </p>
-        </ul>
-        {% elif status == "CKAN and Keycloak are not reachable." %}
-            <p class="lead text-danger text-center">
-                <i class="fas fa-times-circle"></i> CKAN and Keycloak are not reachable
+        <!-- Local CKAN -->
+        {% if status.ckan_local_enabled %}
+            <p class="text-primary">
+                <strong>Local CKAN:</strong> Enabled
             </p>
-        
+            {% if status.ckan_is_active_local %}
+                <p class="lead text-success">
+                    <i class="fas fa-check-circle"></i> Local CKAN is active and reachable
+                </p>
+            {% else %}
+                <p class="lead text-danger">
+                    <i class="fas fa-times-circle"></i> Local CKAN is not reachable
+                </p>
+            {% endif %}
         {% else %}
-            <p class="lead text-warning text-center">
-                <i class="fas fa-exclamation-circle"></i> Status unknown
+            <p class="text-muted">
+                <strong>Local CKAN:</strong> Disabled
+            </p>
+        {% endif %}
+
+        <!-- Global CKAN -->
+        {% if status.ckan_is_active_global %}
+            <p class="lead text-success">
+                <i class="fas fa-check-circle"></i> Global CKAN is active and reachable
+            </p>
+        {% else %}
+            <p class="lead text-danger">
+                <i class="fas fa-times-circle"></i> Global CKAN is not reachable
+            </p>
+        {% endif %}
+
+        <!-- Keycloak -->
+        {% if status.keycloak_is_active %}
+            <p class="lead text-success">
+                <i class="fas fa-check-circle"></i> Keycloak is active and reachable
+            </p>
+        {% else %}
+            <p class="lead text-danger">
+                <i class="fas fa-times-circle"></i> Keycloak is not reachable
             </p>
         {% endif %}
     </div>
@@ -49,30 +58,29 @@
 <div class="row mt-4 d-flex justify-content-center">
     <!-- Kafka -->
     {% if kafka_info.kafka_connection %}
-    <div class="card card-square shadow-sm">
+    <div class="card card-square shadow-sm mx-2">
         <div class="card-header card-header-custom">
             <h5 class="card-title-custom">Kafka Connection</h5>
         </div>
         <div class="card-body card-body-custom">
-            <p style="font-size: 15px;"><strong>Host:</strong> {{ kafka_info.kafka_host }}</p>
-            <p style="font-size: 15px font-size: 15px; height: 21.5px; transform: translate(0px, -14px);"><strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
+            <p><strong>Host:</strong> {{ kafka_info.kafka_host }}</p>
+            <p><strong>Port:</strong> {{ kafka_info.kafka_port }}</p>
         </div>
     </div>
     {% endif %}
-    <!-- Kafka -->
+
+    <!-- JupyterLab -->
     {% if use_jupyterlab %}
-    <div class="card card-square shadow-sm">
+    <div class="card card-square shadow-sm mx-2">
         <div class="card-header card-header-custom">
             <h5 class="card-title-custom">JupyterLab</h5>
         </div>
         <div class="card-body card-body-custom">
-            <a href="{{ jupyter_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer" style="height: 60px; transform: translate(0px, -9px);">
+            <a href="{{ jupyter_url }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
                 Access JupyterLab
             </a>
         </div>
     </div>
     {% endif %}
 </div>
-
-
 {% endblock %}

--- a/env_variables/example.env_ckan
+++ b/env_variables/example.env_ckan
@@ -1,3 +1,7 @@
+# Indicates whether to enable a local CKAN instance.
+# Set to "True" to enable local CKAN; "False" to disable it.
+CKAN_LOCAL_ENABLED=True
+
 # URL of the CKAN instance where the datasets will be managed or retrieved.
 # This is typically the base URL of your CKAN server.
 CKAN_URL=http://localhost:5000/

--- a/env_variables/example.env_swagger
+++ b/env_variables/example.env_swagger
@@ -9,7 +9,7 @@ SWAGGER_DESCRIPTION=API documentation
 # Version of the API being documented.
 # This version number helps users understand which version of the API they are
 # interacting with.
-SWAGGER_VERSION=0.3.0
+SWAGGER_VERSION=0.4.0
 
 # Set to 'True' if the POP is publicly accessible; 'False' if it's private
 PUBLIC=True

--- a/tests/test_create_organization.py
+++ b/tests/test_create_organization.py
@@ -1,8 +1,17 @@
+import pytest
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 from unittest.mock import patch
 from api.main import app
 from api.services.keycloak_services.get_current_user import get_current_user
+from api.config.ckan_settings import ckan_settings
+
+# Skip every test in this file if local CKAN is disabled
+pytestmark = pytest.mark.skipif(
+    not ckan_settings.ckan_local_enabled,
+    reason="Local CKAN is disabled; skipping organization deletion tests."
+)
+
 
 client = TestClient(app)
 

--- a/tests/test_create_s3_resource.py
+++ b/tests/test_create_s3_resource.py
@@ -1,7 +1,16 @@
+import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 from api.main import app
 from api.services.keycloak_services.get_current_user import get_current_user
+from api.config.ckan_settings import ckan_settings
+
+# Skip every test in this file if local CKAN is disabled
+pytestmark = pytest.mark.skipif(
+    not ckan_settings.ckan_local_enabled,
+    reason="Local CKAN is disabled; skipping organization deletion tests."
+)
+
 
 client = TestClient(app)
 

--- a/tests/test_create_url_resource.py
+++ b/tests/test_create_url_resource.py
@@ -1,8 +1,17 @@
+import pytest
 from fastapi.testclient import TestClient
 from fastapi import HTTPException
 from unittest.mock import patch
 from api.main import app
 from api.services.keycloak_services.get_current_user import get_current_user
+from api.config.ckan_settings import ckan_settings
+
+# Skip every test in this file if local CKAN is disabled
+pytestmark = pytest.mark.skipif(
+    not ckan_settings.ckan_local_enabled,
+    reason="Local CKAN is disabled; skipping organization deletion tests."
+)
+
 
 client = TestClient(app)
 

--- a/tests/test_delete_organization.py
+++ b/tests/test_delete_organization.py
@@ -1,6 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 from api.main import app  # Import your FastAPI application
+from api.config.ckan_settings import ckan_settings
+
+# Skip every test in this file if local CKAN is disabled
+pytestmark = pytest.mark.skipif(
+    not ckan_settings.ckan_local_enabled,
+    reason="Local CKAN is disabled; skipping organization deletion tests."
+)
+
 
 client = TestClient(app)
 


### PR DESCRIPTION
**Summary of Changes**
- Added a new `CKAN_LOCAL_ENABLED` variable in `.env_ckan` to make local CKAN optional.
- Updated route inclusion logic so endpoints for CKAN-based features are only mounted if `CKAN_LOCAL_ENABLED` is `True`.
- Refactored the status checks to provide both local and global CKAN reachability info, and updated the index template to display these statuses.
- Introduced new styling across the dashboard (Local CKAN, Kafka, JupyterLab) to keep a consistent Bootstrap card layout.
- Implemented `pytest.skipif` logic and route existence checks to skip tests when local CKAN is disabled or relevant endpoints are not mounted, avoiding unnecessary 404/405 failures.
- Ran `flake8` to ensure code cleanliness and consistency.

