### PR TITLE
feat: add optional query param server to POST /url for local or pre_ckan

### DIFF
--- a/api/routes/register_routes/post_url.py
+++ b/api/routes/register_routes/post_url.py
@@ -9,6 +9,7 @@ from api.config import ckan_settings
 
 router = APIRouter()
 
+
 @router.post(
     "/url",
     response_model=dict,
@@ -63,8 +64,8 @@ async def create_url_resource(
     """
     Add a URL resource to CKAN.
 
-    If server='pre_ckan', uses the pre-CKAN instance if enabled. Otherwise, 
-    defaults to local CKAN. A 400 error is returned if pre_ckan is disabled 
+    If server='pre_ckan', uses the pre-CKAN instance if enabled. Otherwise,
+    defaults to local CKAN. A 400 error is returned if pre_ckan is disabled
     or the URL has no valid scheme.
 
     Parameters
@@ -84,7 +85,7 @@ async def create_url_resource(
     Raises
     ------
     HTTPException
-        - 400: If there's an error creating the resource, or if pre_ckan 
+        - 400: If there's an error creating the resource, or if pre_ckan
           is disabled, or if there's no valid scheme.
     """
     try:


### PR DESCRIPTION
This pull request introduces an optional `server` query parameter 
to the POST /url endpoint, allowing users to specify either 'local' 
or 'pre_ckan'. If no server is provided, the endpoint defaults to 'local'.

**Changes**  
1. Accepts `?server=local` or `?server=pre_ckan` in the POST /url route.  
2. If `server=pre_ckan` is used but `pre_ckan_enabled` is False, 
   a 400 error is returned with a clear message.  
3. If the pre_ckan URL lacks a valid scheme, a friendly 
   "Pre-CKAN server is not configured or unreachable." error is shown.  
4. Maintains backward compatibility by defaulting to `local` when no 
   server parameter is given.

**Impact**  
- Allows explicit selection of the CKAN instance for URL resources.  
- Returns user-friendly errors if pre_ckan is disabled or misconfigured.  
- No breaking changes for existing clients that do not pass a server param.

**Testing**  
- Verified locally that `?server=pre_ckan` works if `pre_ckan_enabled=True` 
  and the URL has a valid scheme.  
- Confirmed that calls without `?server` default to `local`, preserving 
  original behavior.
