### PR TITLE
feat: add optional ?server=local/pre_ckan query param to PUT /s3/{resource_id}

### DIFF
--- a/api/routes/update_routes/put_s3.py
+++ b/api/routes/update_routes/put_s3.py
@@ -9,6 +9,7 @@ from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
 
+
 @router.put(
     "/s3/{resource_id}",
     response_model=dict,

--- a/api/routes/update_routes/put_s3.py
+++ b/api/routes/update_routes/put_s3.py
@@ -1,3 +1,4 @@
+# api/routes/update_routes/put_s3.py
 from fastapi import APIRouter, HTTPException, status, Depends
 from api.services.s3_services.update_s3 import update_s3
 from api.models.update_s3_model import S3ResourceUpdateRequest

--- a/api/routes/update_routes/put_s3.py
+++ b/api/routes/update_routes/put_s3.py
@@ -1,39 +1,39 @@
 # api/routes/update_routes/put_s3.py
-from fastapi import APIRouter, HTTPException, status, Depends
+
+from fastapi import APIRouter, HTTPException, status, Depends, Query
+from typing import Dict, Any, Literal
 from api.services.s3_services.update_s3 import update_s3
 from api.models.update_s3_model import S3ResourceUpdateRequest
-from typing import Dict, Any
-
 from api.services.keycloak_services.get_current_user import get_current_user
-
+from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
-
 
 @router.put(
     "/s3/{resource_id}",
     response_model=dict,
     status_code=status.HTTP_200_OK,
     summary="Update an existing S3 resource",
-    description="""
-Update an existing S3 resource and its associated metadata.
-
-### Optional Fields
-- **resource_name**: The unique name of the resource to be updated.
-- **resource_title**: The title of the resource to be updated.
-- **owner_org**: The ID of the organization to which the resource belongs.
-- **resource_s3**: The S3 URL of the resource.
-- **notes**: Additional notes about the resource.
-- **extras**: Additional metadata to be updated or added to the resource.
-
-### Example Payload
-```json
-{
-    "resource_name": "updated_resource_name",
-    "resource_s3": "http://new-s3-url.com/resource"
-}
-```
-""",
+    description=(
+        "Update an existing S3 resource and its associated metadata.\n\n"
+        "### Optional Fields\n"
+        "- **resource_name**: The unique name of the resource.\n"
+        "- **resource_title**: The title of the resource.\n"
+        "- **owner_org**: The ID of the organization.\n"
+        "- **resource_s3**: The S3 URL of the resource.\n"
+        "- **notes**: Additional notes.\n"
+        "- **extras**: Additional metadata.\n\n"
+        "### Query Parameter\n"
+        "Use `?server=local` or `?server=pre_ckan` to choose which CKAN "
+        "instance to update. Defaults to 'local' if not provided.\n\n"
+        "### Example Payload\n"
+        "```json\n"
+        "{\n"
+        '    "resource_name": "updated_resource_name",\n'
+        '    "resource_s3": "http://new-s3-url.com/resource"\n'
+        "}\n"
+        "```\n"
+    ),
     responses={
         200: {
             "description": "S3 resource updated successfully",
@@ -48,7 +48,9 @@ Update an existing S3 resource and its associated metadata.
             "content": {
                 "application/json": {
                     "example": {
-                        "detail": "Error updating S3 resource: <error message>"
+                        "detail": (
+                            "Error updating S3 resource: <error message>"
+                        )
                     }
                 }
             }
@@ -63,22 +65,57 @@ Update an existing S3 resource and its associated metadata.
         }
     }
 )
-async def update_s3_resource(resource_id: str,
-                             data: S3ResourceUpdateRequest,
-                             _: Dict[str, Any] = Depends(get_current_user)):
+async def update_s3_resource(
+    resource_id: str,
+    data: S3ResourceUpdateRequest,
+    server: Literal["local", "pre_ckan"] = Query(
+        "local",
+        description="Choose 'local' or 'pre_ckan'. Defaults to 'local'."
+    ),
+    _: Dict[str, Any] = Depends(get_current_user)
+):
+    """
+    Update an existing S3 resource in CKAN.
+
+    If ?server=pre_ckan is used and pre_ckan is enabled/configured,
+    updates the resource in the pre-CKAN instance. Otherwise defaults
+    to local CKAN. Returns a 400 error if pre_ckan is disabled or
+    missing a valid scheme.
+    """
     try:
-        updated = await update_s3(
+        # Determine CKAN instance
+        if server == "pre_ckan":
+            if not ckan_settings.pre_ckan_enabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Pre-CKAN is disabled and cannot be used."
+                )
+            ckan_instance = ckan_settings.pre_ckan
+        else:
+            ckan_instance = ckan_settings.ckan
+
+        updated_id = await update_s3(
             resource_id=resource_id,
             resource_name=data.resource_name,
             resource_title=data.resource_title,
             owner_org=data.owner_org,
             resource_s3=data.resource_s3,
             notes=data.notes,
-            extras=data.extras
+            extras=data.extras,
+            ckan_instance=ckan_instance
         )
-        if not updated:
+        if not updated_id:
             raise HTTPException(
-                status_code=404, detail="S3 resource not found")
+                status_code=404,
+                detail="S3 resource not found"
+            )
         return {"message": "S3 resource updated successfully"}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+
+    except Exception as exc:
+        error_msg = str(exc)
+        if "No scheme supplied" in error_msg:
+            raise HTTPException(
+                status_code=400,
+                detail="Pre-CKAN server is not configured or unreachable."
+            )
+        raise HTTPException(status_code=400, detail=error_msg)

--- a/api/services/s3_services/update_s3.py
+++ b/api/services/s3_services/update_s3.py
@@ -7,6 +7,7 @@ RESERVED_KEYS = {
     'name', 'title', 'owner_org', 'notes', 'id', 'resources', 'collection'
 }
 
+
 async def update_s3(
     resource_id: str,
     resource_name: Optional[str] = None,

--- a/api/services/s3_services/update_s3.py
+++ b/api/services/s3_services/update_s3.py
@@ -1,10 +1,11 @@
+# api/services/s3_services/update_s3.py
+
 from typing import Dict, Optional
 from api.config.ckan_settings import ckan_settings
 
-
 RESERVED_KEYS = {
-    'name', 'title', 'owner_org', 'notes', 'id', 'resources', 'collection'}
-
+    'name', 'title', 'owner_org', 'notes', 'id', 'resources', 'collection'
+}
 
 async def update_s3(
     resource_id: str,
@@ -13,13 +14,19 @@ async def update_s3(
     owner_org: Optional[str] = None,
     resource_s3: Optional[str] = None,
     notes: Optional[str] = None,
-    extras: Optional[Dict[str, str]] = None
+    extras: Optional[Dict[str, str]] = None,
+    ckan_instance=None  # new optional parameter
 ):
-    ckan = ckan_settings.ckan
+    """
+    Update an existing S3 resource in CKAN, supporting a custom ckan_instance.
+    If ckan_instance is None, defaults to ckan_settings.ckan.
+    """
+    if ckan_instance is None:
+        ckan_instance = ckan_settings.ckan
 
     try:
         # Fetch the existing resource
-        resource = ckan.action.package_show(id=resource_id)
+        resource = ckan_instance.action.package_show(id=resource_id)
     except Exception as e:
         raise Exception(f"Error fetching S3 resource: {str(e)}")
 
@@ -31,28 +38,32 @@ async def update_s3(
 
     # Handle extras update by merging current extras with new ones
     current_extras = {
-        extra['key']: extra['value'] for extra in resource.get('extras', [])}
+        extra['key']: extra['value'] for extra in resource.get('extras', [])
+    }
 
     if extras:
         if RESERVED_KEYS.intersection(extras):
             raise KeyError(
                 "Extras contain reserved keys: "
-                f"{RESERVED_KEYS.intersection(extras)}")
+                f"{RESERVED_KEYS.intersection(extras)}"
+            )
         current_extras.update(extras)
 
     resource['extras'] = [
-        {'key': k, 'value': v} for k, v in current_extras.items()]
+        {'key': k, 'value': v} for k, v in current_extras.items()
+    ]
 
     try:
         # Update the resource package in CKAN
-        updated_resource = ckan.action.package_update(**resource)
+        updated_resource = ckan_instance.action.package_update(**resource)
 
         # If the S3 URL is updated, update the corresponding resource
         if resource_s3:
             for res in resource['resources']:
                 if res['format'].lower() == 's3':
-                    ckan.action.resource_update(
-                        id=res['id'], url=resource_s3, package_id=resource_id)
+                    ckan_instance.action.resource_update(
+                        id=res['id'], url=resource_s3, package_id=resource_id
+                    )
                     break
     except Exception as e:
         raise Exception(f"Error updating S3 resource: {str(e)}")


### PR DESCRIPTION
**Overview**  
This pull request introduces an optional server query parameter to the 
PUT /s3/{resource_id} endpoint, allowing users to specify whether they 
want to update the S3 resource in a local CKAN instance or a pre-CKAN 
instance. By default, if no server is provided, the route continues to 
use the local CKAN.

**Changes**  
1. Added a `ckan_instance` parameter to the `update_s3` function so it 
   no longer relies solely on ckan_settings.ckan.  
2. Implemented ?server=local or ?server=pre_ckan in the PUT /s3/{resource_id} 
   route, returning a 400 error if pre_ckan is disabled or lacks a valid 
   URL scheme.  
3. Preserved backward compatibility for calls that do not specify any 
   server parameter.

**Impact**  
- Users can explicitly select which CKAN instance (local or pre_ckan) 
  to update S3 resources on.  
- Provides clear error handling if pre_ckan is disabled or improperly 
  configured.  
- No breaking changes for existing clients that omit the server parameter.

**Testing**  
- Verified locally that `PUT /s3/{resource_id}?server=pre_ckan` updates 
  the resource on pre_ckan if enabled and configured.  
- Confirmed that calls without ?server continue using the local CKAN 
  instance as before.
