### PR TITLE
feat: add optional ?server=local/pre_ckan to DELETE /organization/{organization_name}

### DIFF
--- a/api/routes/delete_routes/delete_organization_route.py
+++ b/api/routes/delete_routes/delete_organization_route.py
@@ -1,11 +1,11 @@
 # api/routes/delete_routes/delete_organization_route.py
-from fastapi import APIRouter, HTTPException
 
+from fastapi import APIRouter, HTTPException, Query
+from typing import Literal
 from api.services import organization_services
-
+from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
-
 
 @router.delete(
     "/organization/{organization_name}",
@@ -13,7 +13,8 @@ router = APIRouter()
     summary="Delete an organization",
     description=(
         "Delete an organization from CKAN by its name, including "
-        "all associated datasets and resources."),
+        "all associated datasets and resources."
+    ),
     responses={
         200: {
             "description": "Organization deleted successfully",
@@ -28,7 +29,8 @@ router = APIRouter()
             "content": {
                 "application/json": {
                     "example": {
-                        "detail": "Error message explaining the bad request"}
+                        "detail": "Error message explaining the bad request"
+                    }
                 }
             }
         },
@@ -42,28 +44,45 @@ router = APIRouter()
         }
     }
 )
-async def delete_organization(organization_name: str):
+async def delete_organization(
+    organization_name: str,
+    server: Literal["local", "pre_ckan"] = Query(
+        "local",
+        description="Choose 'local' or 'pre_ckan'. Defaults to 'local'."
+    )
+):
     """
     Endpoint to delete an organization in CKAN by its name.
 
-    Parameters
-    ----------
-    organization_name : str
-        The name of the organization to be deleted.
-
-    Returns
-    -------
-    dict
-        A message confirming the deletion of the organization.
-
-    Raises
-    ------
-    HTTPException
-        If there is an error deleting the organization, an HTTPException is
-        raised with a detailed message.
+    If ?server=pre_ckan is used, it will delete from the pre-CKAN instance
+    if enabled. Returns a 400 error if pre_ckan is disabled or missing a
+    valid scheme. Raises a 404 if the organization does not exist.
     """
     try:
-        organization_services.delete_organization(organization_name)
+        # Determine which CKAN instance to use
+        if server == "pre_ckan":
+            if not ckan_settings.pre_ckan_enabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Pre-CKAN is disabled and cannot be used."
+                )
+            ckan_instance = ckan_settings.pre_ckan
+        else:
+            ckan_instance = ckan_settings.ckan
+
+        organization_services.delete_organization(
+            organization_name=organization_name,
+            ckan_instance=ckan_instance
+        )
         return {"message": "Organization deleted successfully"}
+
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        error_msg = str(e)
+        if "Organization not found" in error_msg:
+            raise HTTPException(status_code=404, detail="Organization not found")
+        if "No scheme supplied" in error_msg:
+            raise HTTPException(
+                status_code=400,
+                detail="Pre-CKAN server is not configured or unreachable."
+            )
+        raise HTTPException(status_code=400, detail=error_msg)

--- a/api/routes/delete_routes/delete_organization_route.py
+++ b/api/routes/delete_routes/delete_organization_route.py
@@ -7,6 +7,7 @@ from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
 
+
 @router.delete(
     "/organization/{organization_name}",
     response_model=dict,
@@ -79,7 +80,8 @@ async def delete_organization(
     except Exception as e:
         error_msg = str(e)
         if "Organization not found" in error_msg:
-            raise HTTPException(status_code=404, detail="Organization not found")
+            raise HTTPException(
+                status_code=404, detail="Organization not found")
         if "No scheme supplied" in error_msg:
             raise HTTPException(
                 status_code=400,

--- a/api/routes/delete_routes/delete_organization_route.py
+++ b/api/routes/delete_routes/delete_organization_route.py
@@ -1,3 +1,4 @@
+# api/routes/delete_routes/delete_organization_route.py
 from fastapi import APIRouter, HTTPException
 
 from api.services import organization_services

--- a/api/services/organization_services/delete_organization.py
+++ b/api/services/organization_services/delete_organization.py
@@ -2,6 +2,7 @@
 from ckanapi import NotFound
 from api.config.ckan_settings import ckan_settings
 
+
 def delete_organization(
     organization_name: str,
     ckan_instance=None  # new optional parameter

--- a/api/services/organization_services/delete_organization.py
+++ b/api/services/organization_services/delete_organization.py
@@ -1,37 +1,36 @@
+# api/services/organization_services/delete_organization.py
 from ckanapi import NotFound
 from api.config.ckan_settings import ckan_settings
 
-
-def delete_organization(organization_name: str):
+def delete_organization(
+    organization_name: str,
+    ckan_instance=None  # new optional parameter
+):
     """
-    Delete an organization from CKAN by its name.
-
-    Parameters
-    ----------
-    organization_name : str
-        The name of the organization to be deleted.
-
-    Raises
-    ------
-    Exception
-        If there is an error deleting the organization.
+    Delete an organization from CKAN by its name, optionally using a
+    custom ckan_instance. Defaults to ckan_settings.ckan if none is provided.
     """
-    ckan = ckan_settings.ckan
+    if ckan_instance is None:
+        ckan_instance = ckan_settings.ckan
 
     try:
-        # Retrieve the organization to ensure it exists and get its ID
-        organization = ckan.action.organization_show(id=organization_name)
+        # Retrieve the organization to ensure it exists
+        organization = ckan_instance.action.organization_show(
+            id=organization_name
+        )
         organization_id = organization['id']
 
         # Delete all datasets associated with the organization
-        datasets = ckan.action.package_search(
-            fq=f'owner_org:{organization_id}', rows=1000)
+        datasets = ckan_instance.action.package_search(
+            fq=f'owner_org:{organization_id}', rows=1000
+        )
         for dataset in datasets['results']:
-            ckan.action.dataset_purge(id=dataset['id'])
+            ckan_instance.action.dataset_purge(id=dataset['id'])
 
         # Delete the organization
-        ckan.action.organization_delete(id=organization_id)
-        ckan.action.organization_purge(id=organization_id)
+        ckan_instance.action.organization_delete(id=organization_id)
+        ckan_instance.action.organization_purge(id=organization_id)
+
     except NotFound:
         raise Exception("Organization not found")
     except Exception as e:

--- a/tests/test_delete_organization.py
+++ b/tests/test_delete_organization.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.skipif(
 
 client = TestClient(app)
 
+
 def test_delete_organization_success():
     """
     Test that an organization is successfully deleted, returning 200.
@@ -34,6 +35,7 @@ def test_delete_organization_success():
             ckan_instance=ANY
         )
 
+
 def test_delete_organization_not_found():
     """
     Test that a non-existent organization returns a 404 status.
@@ -53,6 +55,7 @@ def test_delete_organization_not_found():
             organization_name=organization_name,
             ckan_instance=ANY
         )
+
 
 def test_delete_organization_error():
     """

--- a/tests/test_delete_organization.py
+++ b/tests/test_delete_organization.py
@@ -1,7 +1,8 @@
+# tests/test_delete_organization.py
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch
-from api.main import app  # Import your FastAPI application
+from unittest.mock import patch, ANY
+from api.main import app
 from api.config.ckan_settings import ckan_settings
 
 # Skip every test in this file if local CKAN is disabled
@@ -10,46 +11,64 @@ pytestmark = pytest.mark.skipif(
     reason="Local CKAN is disabled; skipping organization deletion tests."
 )
 
-
 client = TestClient(app)
 
-
 def test_delete_organization_success():
-    # Mock the 'delete_organization' function to simulate successful deletion
+    """
+    Test that an organization is successfully deleted, returning 200.
+    """
     with patch(
         'api.services.organization_services.delete_organization'
     ) as mock_delete:
-        mock_delete.return_value = None  # No exception means success
+        mock_delete.return_value = None  # No exception => success
+
         organization_name = "test_organization"
         response = client.delete(f"/organization/{organization_name}")
         assert response.status_code == 200
         assert response.json() == {
-            "message": "Organization deleted successfully"}
-        mock_delete.assert_called_once_with(organization_name)
-
+            "message": "Organization deleted successfully"
+        }
+        # Accept that ckan_instance is also passed
+        mock_delete.assert_called_once_with(
+            organization_name=organization_name,
+            ckan_instance=ANY
+        )
 
 def test_delete_organization_not_found():
-    # Mock the 'delete_organization' function to raise an exception for not
-    # found
+    """
+    Test that a non-existent organization returns a 404 status.
+    """
     with patch(
         'api.services.organization_services.delete_organization'
     ) as mock_delete:
         mock_delete.side_effect = Exception("Organization not found")
+
         organization_name = "nonexistent_organization"
         response = client.delete(f"/organization/{organization_name}")
-        assert response.status_code == 400
+        # The route now returns 404 if "Organization not found"
+        assert response.status_code == 404
         assert response.json() == {"detail": "Organization not found"}
-        mock_delete.assert_called_once_with(organization_name)
 
+        mock_delete.assert_called_once_with(
+            organization_name=organization_name,
+            ckan_instance=ANY
+        )
 
 def test_delete_organization_error():
-    # Mock the 'delete_organization' function to raise a general exception
+    """
+    Test that a general error in deleting the organization returns 400.
+    """
     with patch(
         'api.services.organization_services.delete_organization'
     ) as mock_delete:
         mock_delete.side_effect = Exception("An unexpected error occurred")
+
         organization_name = "test_organization"
         response = client.delete(f"/organization/{organization_name}")
         assert response.status_code == 400
         assert response.json() == {"detail": "An unexpected error occurred"}
-        mock_delete.assert_called_once_with(organization_name)
+
+        mock_delete.assert_called_once_with(
+            organization_name=organization_name,
+            ckan_instance=ANY
+        )


### PR DESCRIPTION
This pull request adds an optional server query parameter to the 
DELETE /organization/{organization_name} endpoint, allowing users 
to delete organizations from either the local CKAN or a pre-CKAN instance. 
It also aligns the test suite with the new behavior, including the 
404 status code for non-existent organizations.

**Changes**  
1. Added a ckan_instance parameter in delete_organization to avoid relying 
   solely on ckan_settings.ckan.  
2. Implemented ?server=local or ?server=pre_ckan in the DELETE /organization 
   route.  
3. Returns a 400 error if pre_ckan is disabled or missing a valid URL scheme.  
4. Returns 404 if the organization does not exist.  
5. Updated tests/test_delete_organization.py to:
   - Use ANY to ignore the ckan_instance parameter.  
   - Expect a 404 status code for "Organization not found."

**Impact**  
- Users can explicitly select which CKAN instance to delete an organization 
  from.  
- Maintains backward compatibility by defaulting to local CKAN if the server 
  parameter is omitted.  
- Provides user-friendly error messages for disabled or misconfigured 
  pre_ckan.  
- The tests now correctly handle the new 404 vs. 400 behavior.

**Testing**  
- Verified locally that ?server=pre_ckan calls delete_organization with 
  pre_ckan, returning 400 if disabled or "No scheme supplied."  
- Confirmed that calls without ?server remain on local CKAN.  
- The test suite now passes with the updated expectations.
