### PR TITLE
feat: add optional ?server=local/pre_ckan to DELETE /resource and /resource/{resource_name}

### DIFF
--- a/api/routes/delete_routes/delete_dataset.py
+++ b/api/routes/delete_routes/delete_dataset.py
@@ -1,11 +1,12 @@
-# api/routes/delete_routes/delete_dataset.py
-from fastapi import APIRouter, HTTPException, Query
-from api.services import dataset_services
-from typing import Annotated
+# api/routes/delete_routes/resource_delete_route.py
+# English code comments, PEP-8 lines <=79 chars
 
+from fastapi import APIRouter, HTTPException, Query
+from typing import Annotated, Literal
+from api.services import dataset_services
+from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
-
 
 @router.delete(
     "/resource",
@@ -45,32 +46,43 @@ async def delete_resource(
     resource_id: Annotated[
         str,
         Query(description="The ID of the dataset to delete.")
-    ]
+    ],
+    server: Literal["local", "pre_ckan"] = Query(
+        "local",
+        description="Choose 'local' or 'pre_ckan'. Defaults to 'local'."
+    )
 ):
     """
-    Endpoint to delete a resource by its type and name.
+    Endpoint to delete a dataset by its resource_id.
 
-    Parameters
-    ----------
-    resource_id : str
-        The id of the resource to be deleted.
-
-    Returns
-    -------
-    dict
-        A message confirming the deletion of the resource.
-
-    Raises
-    ------
-    HTTPException
-        If there is an error deleting the resource, an HTTPException is
-        raised with a detailed message.
+    If ?server=pre_ckan is provided and pre_ckan is enabled, deletes from
+    the pre-CKAN instance. Otherwise defaults to local CKAN.
     """
     try:
-        dataset_services.delete_dataset(resource_id=resource_id)
+        if server == "pre_ckan":
+            if not ckan_settings.pre_ckan_enabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Pre-CKAN is disabled and cannot be used."
+                )
+            ckan_instance = ckan_settings.pre_ckan
+        else:
+            ckan_instance = ckan_settings.ckan
+
+        dataset_services.delete_dataset(resource_id=resource_id,
+                                        ckan_instance=ckan_instance)
         return {"message": f"{resource_id} deleted successfully"}
+
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        error_msg = str(e)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Resource not found")
+        if "No scheme supplied" in error_msg:
+            raise HTTPException(
+                status_code=400,
+                detail="Pre-CKAN server is not configured or unreachable."
+            )
+        raise HTTPException(status_code=400, detail=error_msg)
 
 
 @router.delete(
@@ -107,28 +119,41 @@ async def delete_resource(
         }
     }
 )
-async def delete_resource_by_name(resource_name: str):
+async def delete_resource_by_name(
+    resource_name: str,
+    server: Literal["local", "pre_ckan"] = Query(
+        "local",
+        description="Choose 'local' or 'pre_ckan'. Defaults to 'local'."
+    )
+):
     """
-    Endpoint to delete a resource by its type and name.
+    Endpoint to delete a dataset by its name.
 
-    Parameters
-    ----------
-    resource_name : str
-        The name of the resource to be deleted.
-
-    Returns
-    -------
-    dict
-        A message confirming the deletion of the resource.
-
-    Raises
-    ------
-    HTTPException
-        If there is an error deleting the resource, an HTTPException is
-        raised with a detailed message.
+    If ?server=pre_ckan is provided and pre_ckan is enabled, deletes from
+    the pre-CKAN instance. Otherwise defaults to local CKAN.
     """
     try:
-        dataset_services.delete_dataset(dataset_name=resource_name)
+        if server == "pre_ckan":
+            if not ckan_settings.pre_ckan_enabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Pre-CKAN is disabled and cannot be used."
+                )
+            ckan_instance = ckan_settings.pre_ckan
+        else:
+            ckan_instance = ckan_settings.ckan
+
+        dataset_services.delete_dataset(dataset_name=resource_name,
+                                        ckan_instance=ckan_instance)
         return {"message": f"{resource_name} deleted successfully"}
+
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        error_msg = str(e)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Resource not found")
+        if "No scheme supplied" in error_msg:
+            raise HTTPException(
+                status_code=400,
+                detail="Pre-CKAN server is not configured or unreachable."
+            )
+        raise HTTPException(status_code=400, detail=error_msg)

--- a/api/routes/delete_routes/delete_dataset.py
+++ b/api/routes/delete_routes/delete_dataset.py
@@ -1,3 +1,4 @@
+# api/routes/delete_routes/delete_dataset.py
 from fastapi import APIRouter, HTTPException, Query
 from api.services import dataset_services
 from typing import Annotated

--- a/api/routes/delete_routes/delete_dataset.py
+++ b/api/routes/delete_routes/delete_dataset.py
@@ -8,6 +8,7 @@ from api.config.ckan_settings import ckan_settings
 
 router = APIRouter()
 
+
 @router.delete(
     "/resource",
     response_model=dict,

--- a/api/services/dataset_services/delete_dataset.py
+++ b/api/services/dataset_services/delete_dataset.py
@@ -2,6 +2,7 @@
 from ckanapi import NotFound
 from api.config.ckan_settings import ckan_settings
 
+
 def delete_dataset(
     dataset_name: str = None,
     resource_id: str = None,

--- a/api/services/dataset_services/delete_dataset.py
+++ b/api/services/dataset_services/delete_dataset.py
@@ -1,42 +1,37 @@
+# api/services/dataset_services/delete_dataset.py
 from ckanapi import NotFound
 from api.config.ckan_settings import ckan_settings
 
-
-def delete_dataset(dataset_name: str = None, resource_id: str = None):
+def delete_dataset(
+    dataset_name: str = None,
+    resource_id: str = None,
+    ckan_instance=None
+):
     """
-    Delete a dataset from CKAN by its name.
-
-    Parameters
-    ----------
-    dataset_name : str
-        The name of the dataset to be deleted.
-    resource_id : str
-        The id of the dataset to be deleted.
-
-    Raises
-    ------
-    Exception
-        If there is an error deleting the dataset.
+    Delete a dataset from CKAN by its name or resource_id, allowing
+    a custom CKAN instance. Defaults to ckan_settings.ckan if none is
+    provided.
     """
-    ckan = ckan_settings.ckan
+    if ckan_instance is None:
+        ckan_instance = ckan_settings.ckan
+
     if not (dataset_name or resource_id):
-        raise ValueError(
-            "must dataset_name and dataset_id cannot both be None.")
+        raise ValueError("Must provide either dataset_name or resource_id.")
 
     try:
         # Retrieve the dataset to ensure it exists
         if dataset_name:
-            dataset = ckan.action.package_show(id=dataset_name)
+            dataset = ckan_instance.action.package_show(id=dataset_name)
             if resource_id and resource_id != dataset['id']:
                 raise ValueError(
-                    f"provided resource_id {resource_id} "
-                    f"but {dataset_name} matches id {dataset['id']}.")
+                    f"Provided resource_id '{resource_id}' does not match "
+                    f"the dataset id '{dataset['id']}' for '{dataset_name}'."
+                )
             resource_id = dataset['id']
-        print(f"Dataset '{dataset_name}' found with ID: {resource_id}")
 
         # Attempt to delete the dataset using its ID
-        ckan.action.dataset_purge(id=resource_id)
-        print(f"Dataset '{dataset_name}' successfully deleted.")
+        ckan_instance.action.dataset_purge(id=resource_id)
+
     except NotFound:
         raise Exception(f"Dataset '{dataset_name}' not found.")
     except Exception as e:


### PR DESCRIPTION
**Overview**  
This pull request introduces an optional server query parameter 
to the DELETE /resource and DELETE /resource/{resource_name} endpoints, 
allowing users to specify whether they want to delete the dataset 
in the local CKAN instance or in the pre-CKAN instance. If no server 
parameter is provided, the endpoints default to local CKAN.

**Changes**  
1. Added a ckan_instance parameter to the delete_dataset function 
   so it no longer relies solely on ckan_settings.ckan.  
2. Implemented ?server=local or ?server=pre_ckan in both DELETE /resource 
   and DELETE /resource/{resource_name} routes.  
3. Returns a 400 error if pre_ckan is disabled or if the pre_ckan URL 
   lacks a valid scheme.  
4. Returns a 404 if the resource is not found.  
5. Maintains backward compatibility by defaulting to 'local' when 
   no server parameter is specified.

**Impact**  
- Users can explicitly select which CKAN instance to delete datasets from.  
- Provides clear error handling for disabled or misconfigured pre_ckan.  
- No breaking changes for existing clients that omit the server parameter.

**Testing**  
- Verified locally that specifying ?server=pre_ckan deletes from 
  the pre-CKAN instance, returning user-friendly errors if it is 
  disabled or has no scheme.  
- Confirmed that calls without ?server remain on local CKAN.  
- Checked that non-existent resources return a 404 status.
