### PR TITLE
fix: Fix swagger_version as constant in settings

### DIFF
--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -1,12 +1,13 @@
 # api/config/swagger_settings.py
 
 from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = "0.4.0"
+    swagger_version: str = Field("0.5.1", exclude=True)
     public: bool = True
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"

--- a/tests/test_kafka_datasource_registration_and_search.py
+++ b/tests/test_kafka_datasource_registration_and_search.py
@@ -60,11 +60,11 @@ def test_kafka_datasource_registration_and_search():
 
     # Step 4: Search for the newly registered dataset
     search_response = client.post(
-        "/search", json={"dataset_name": "integration_test_kafka"})
+        "/search", json={"dataset_name": "integration_test_kafka",
+                         "server": "local"},)
     assert search_response.status_code == 200, "Search request failed."
 
     search_results = search_response.json()
-    print("Search results:", search_results)
 
     found_dataset = next(
         (dataset for dataset in search_results


### PR DESCRIPTION
## Summary
Ensures that `swagger_version` is fixed to "x.x.x" by excluding it from environment variables.

### Changes
- Set swagger_version as fixed using `exclude=True` in Field from Pydantic.
- Updated default swagger_version to "x.x.x".

### Benefits
- Ensures version consistency and prevents accidental overrides from the environment.

### Closes
Closes #50.
