### PR TITLE
fix: Add optional 'server' param to /organization route (#52)

### DIFF
--- a/api/routes/register_routes/post_organization.py
+++ b/api/routes/register_routes/post_organization.py
@@ -1,8 +1,8 @@
 # api/routes/register_routes/post_organization.py
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, status, Depends, Query
 from api.models import OrganizationRequest
 from api.services import organization_services
-from typing import Dict, Any
+from typing import Dict, Any, Literal
 from api.services.keycloak_services.get_current_user import get_current_user
 
 
@@ -44,6 +44,10 @@ router = APIRouter()
 )
 async def create_organization_endpoint(
     org: OrganizationRequest,
+    server: Literal["local", "pre_ckan"] = Query(
+        "local",
+        description="Specify 'local' or 'pre_ckan'. Defaults to 'local'."
+    ),
     _: Dict[str, Any] = Depends(get_current_user)
 ):
     """
@@ -54,6 +58,8 @@ async def create_organization_endpoint(
     org : OrganizationRequest
         An object containing the name, title, and description of
         the organization.
+    server : Literal['local', 'pre_ckan']
+        The CKAN server instance to use.
 
     Returns
     -------
@@ -72,6 +78,7 @@ async def create_organization_endpoint(
             name=org.name,
             title=org.title,
             description=org.description,
+            server=server
         )
         return {
             "id": organization_id,

--- a/api/services/organization_services/create_organization.py
+++ b/api/services/organization_services/create_organization.py
@@ -1,11 +1,13 @@
-from typing import Optional
+# api/services/organization_services/create_organization.py
+from typing import Optional, Literal
 from ckanapi import NotFound, ValidationError
 from api.config.ckan_settings import ckan_settings
 
 
 def create_organization(name: str,
                         title: str,
-                        description: Optional[str] = None) -> str:
+                        description: Optional[str] = None,
+                        server: Literal["local", "pre_ckan"] = "local") -> str:
     """
     Create a new organization in CKAN.
 
@@ -17,6 +19,9 @@ def create_organization(name: str,
         The title of the organization.
     description : Optional[str]
         The description of the organization.
+    server : Literal["local", "pre_ckan"]
+        The server instance where the organization will be created.
+        Defaults to "local".
 
     Returns
     -------
@@ -28,7 +33,19 @@ def create_organization(name: str,
     Exception
         If there is an error creating the organization.
     """
-    ckan = ckan_settings.ckan
+    # Select CKAN instance based on 'server' parameter
+    if server == "pre_ckan":
+        if not ckan_settings.pre_ckan_enabled:
+            raise Exception(
+                "Pre-CKAN is disabled and cannot be used."
+            )
+        ckan = ckan_settings.pre_ckan
+    else:
+        if not ckan_settings.ckan_local_enabled:
+            raise Exception(
+                "Local CKAN is disabled and cannot be used."
+            )
+        ckan = ckan_settings.ckan
 
     try:
         # Create the organization in CKAN

--- a/tests/test_create_organization.py
+++ b/tests/test_create_organization.py
@@ -44,7 +44,8 @@ def test_create_organization_success():
         mock_create.assert_called_once_with(
             name="test_organization",
             title="Test Organization",
-            description="An organization for testing purposes."
+            description="An organization for testing purposes.",
+            server="local"
         )
 
         # Clean up dependency overrides
@@ -68,7 +69,7 @@ def test_create_organization_already_exists():
         data = {
             "name": "existing_organization",
             "title": "Existing Organization",
-            "description": "An organization that already exists."
+            "description": "An organization that already exists.",
         }
 
         response = client.post("/organization", json=data)
@@ -78,7 +79,8 @@ def test_create_organization_already_exists():
         mock_create.assert_called_once_with(
             name="existing_organization",
             title="Existing Organization",
-            description="An organization that already exists."
+            description="An organization that already exists.",
+            server="local"
         )
 
         # Clean up dependency overrides


### PR DESCRIPTION
This PR addresses issue #52 by adding an optional `server` parameter (`local`|`pre_ckan`) to the `/organization` endpoint, aligning it with the existing logic used in other endpoints (e.g., `/kafka`).

### Changes
- Updated `create_organization` service to accept a `server` parameter.
- Updated `/organization` endpoint to handle optional `server` query parameter.
- Adjusted existing tests to include the new `server` parameter.

### Tests
- All existing tests updated and passing.

### Related Issue