### PR TITLE
[Feature] Persist system metrics to log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .env*
 .venv
+/logs

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,8 @@
 # api/main.py
 
 import logging
+from logging.handlers import RotatingFileHandler
+import os
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,11 +16,35 @@ import api.routes as routes
 from api.config import swagger_settings, ckan_settings
 
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s]: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
+# Define the format for all logs (timestamp, level, message)
+log_formatter = logging.Formatter(
+    '%(asctime)s [%(levelname)s]: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
 )
+
+# Define the path for the log file
+log_file = os.path.join("logs", "metrics.log")
+
+# Create the 'logs' directory if it does not exist
+os.makedirs("logs", exist_ok=True)
+
+# Create a rotating file handler: 5MB per file, keep 3 backups
+file_handler = RotatingFileHandler(
+    log_file, maxBytes=5 * 1024 * 1024, backupCount=3
+)
+file_handler.setFormatter(log_formatter)
+file_handler.setLevel(logging.INFO)
+
+# Create a console handler for stdout logging
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(log_formatter)
+console_handler.setLevel(logging.INFO)
+
+# Configure the root logger to use both handlers
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.INFO)
+root_logger.addHandler(file_handler)
+root_logger.addHandler(console_handler)
 
 
 @asynccontextmanager

--- a/api/main.py
+++ b/api/main.py
@@ -18,7 +18,7 @@ from api.config import swagger_settings, ckan_settings
 
 # Define the format for all logs (timestamp, level, message)
 log_formatter = logging.Formatter(
-    '%(asctime)s [%(levelname)s]: %(message)s',
+    '%(asctime)s [%(levelname)s] %(name)s: %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./tests:/code/tests
       - ./static:/code/static
       - ./pytest.ini:/code/pytest.ini
+      - ./logs:/code/logs
     environment:
       - PYTHONPATH=/code
     networks:


### PR DESCRIPTION
This PR implements issue #63 by configuring the logging system to persist  
metrics from `record_system_metrics()` into a rotating file `logs/metrics.log`.

### Changes included:  
- Replaced `logging.basicConfig` with `RotatingFileHandler` setup  
- Created a `logs/` directory if it does not exist  
- Logs are now written both to stdout and to `logs/metrics.log`  
- Log file rotates at 5MB, keeping 3 backups  
- Updated `docker-compose.yml` to mount the logs folder for persistence

---

### ✅ Closes  
Closes #63