### PR TITLE
[Task] Include service URLs and flags in system metrics logs

### DIFF
--- a/api/config/dxspaces_settings.py
+++ b/api/config/dxspaces_settings.py
@@ -1,3 +1,4 @@
+# api\config\dxspaces_settings.py
 from pydantic_settings import BaseSettings
 
 
@@ -23,6 +24,7 @@ class RegistrationTest:
 
 
 class Settings(BaseSettings):
+    dxspaces_enabled: bool = True
     dxspaces_url: str = "http://localhost:8001"
     dxspaces_registration: str = ""
 

--- a/api/config/keycloak_settings.py
+++ b/api/config/keycloak_settings.py
@@ -1,7 +1,9 @@
+# api\config\keycloak_settings.py
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    keycloak_enabled: bool = True
     keycloak_url: str = "http://localhost:5000"
     realm_name: str = "test"
     client_id: str = "test"

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -8,7 +8,8 @@ from api.services.status_services import get_public_ip, get_system_metrics
 from api.config.swagger_settings import swagger_settings
 from api.config.ckan_settings import ckan_settings
 from api.config.kafka_settings import kafka_settings
-
+from api.config.keycloak_settings import keycloak_settings
+from api.config.dxspaces_settings import dxspaces_settings
 
 logger = logging.getLogger(__name__)
 

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -58,6 +58,12 @@ async def record_system_metrics():
                     "url": keycloak_settings.keycloak_url
                 }
 
+            if (dxspaces_settings.dxspaces_enabled
+                    and dxspaces_settings.dxspaces_url):
+                services["dxspaces"] = {
+                    "url": dxspaces_settings.dxspaces_url
+                }
+
             metrics_payload = {
                 "public_ip": public_ip,
                 "cpu": f"{cpu}%",

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -46,6 +46,11 @@ async def record_system_metrics():
                     "port": kafka_settings.kafka_port,
                     "prefix": kafka_settings.kafka_prefix
                 }
+            
+            if keycloak_settings.keycloak_enabled and keycloak_settings.keycloak_url:
+                services["keycloak"] = {
+                    "url": keycloak_settings.keycloak_url
+                }
 
             metrics_payload = {
                 "public_ip": public_ip,

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -32,13 +32,19 @@ async def record_system_metrics():
             services = {}
 
             if swagger_settings.use_jupyterlab:
-                services["jupyter"] = swagger_settings.jupyter_url
+                services["jupyter"] = {
+                    "url": swagger_settings.jupyter_url
+                }
 
             if ckan_settings.pre_ckan_enabled:
-                services["pre_ckan"] = ckan_settings.pre_ckan_url
+                services["pre_ckan"] = {
+                    "url": ckan_settings.pre_ckan_url
+                }
 
             if ckan_settings.ckan_local_enabled:
-                services["local_ckan"] = ckan_settings.ckan_url
+                services["local_ckan"] = {
+                    "url": ckan_settings.ckan_url
+                }
 
             if kafka_settings.kafka_connection:
                 services["kafka"] = {
@@ -46,7 +52,7 @@ async def record_system_metrics():
                     "port": kafka_settings.kafka_port,
                     "prefix": kafka_settings.kafka_prefix
                 }
-            
+
             if keycloak_settings.keycloak_enabled and keycloak_settings.keycloak_url:
                 services["keycloak"] = {
                     "url": keycloak_settings.keycloak_url


### PR DESCRIPTION
This PR implements issue #65 by enhancing the system metrics logs with  
structured information from active services. Each service now includes its  
URL or host/port in a consistent JSON format.

Additionally, new `enabled` flags were added to control which services are  
included in the logs:

- `keycloak_enabled` (default: True)
- `dxspaces_enabled` (default: True)

### Changes included:  
- Added `keycloak_enabled` and `dxspaces_enabled` settings  
- Structured service entries (e.g., `{"url": ...}`) for:
  - Keycloak  
  - DXSpaces  
  - JupyterLab  
  - CKAN  
  - Pre-CKAN  
- Services are logged only if explicitly enabled

---

### ✅ Closes  
Closes #65