### PR TITLE
[Feature] Expose DXSpaces integration in dashboard (#69)

### DIFF
--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -1,7 +1,6 @@
 # api/config/swagger_settings.py
 
 from pydantic_settings import BaseSettings
-from pydantic import Field
 
 
 class Settings(BaseSettings):

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -7,15 +7,13 @@ from pydantic import Field
 class Settings(BaseSettings):
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
-    swagger_version: str = Field("0.6.0", exclude=True)
+    swagger_version: str = "0.6.0"
     public: bool = True
     metrics_endpoint: str = "http://fed-api:80/metrics/"
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"
     use_dxspaces: bool = False
     dxspaces_url: str = "http://localhost:8001"
-    use_dataspaces: bool = False
-    dataspaces_url: str = "http://localhost:9000"
 
     model_config = {
         "env_file": "./env_variables/.env_swagger",

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     metrics_endpoint: str = "http://fed-api:80/metrics/"
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"
+    use_dxspaces: bool = False
+    dxspaces_url: str = "http://localhost:8001"
+    use_dataspaces: bool = False
+    dataspaces_url: str = "http://localhost:9000"
 
     model_config = {
         "env_file": "./env_variables/.env_swagger",

--- a/api/routes/default_routes/__init__.py
+++ b/api/routes/default_routes/__init__.py
@@ -1,3 +1,4 @@
+# api\routes\default_routes\__init__.py
 from fastapi import APIRouter
 
 from .get import router as get_router

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -40,7 +40,7 @@ def index(request: Request):
             "use_jupyterlab": use_jupyterlab,
             "jupyter_url": jupyter_url,
             "use_dxspaces": use_dxspaces,
-            "dxspaces_url": dxspaces_url 
+            "dxspaces_url": dxspaces_url
 
         }
     )

--- a/api/services/default_services/index.py
+++ b/api/services/default_services/index.py
@@ -24,6 +24,10 @@ def index(request: Request):
     use_jupyterlab = swagger_settings.use_jupyterlab
     jupyter_url = swagger_settings.jupyter_url if use_jupyterlab else None
 
+    # Add dxspaces settings to context
+    use_dxspaces = swagger_settings.use_dxspaces
+    dxspaces_url = swagger_settings.dxspaces_url if use_dxspaces else None
+
     return templates.TemplateResponse(
         request=request,
         name="index.html",
@@ -34,6 +38,9 @@ def index(request: Request):
             "status": status,
             "kafka_info": kafka_info,
             "use_jupyterlab": use_jupyterlab,
-            "jupyter_url": jupyter_url
+            "jupyter_url": jupyter_url,
+            "use_dxspaces": use_dxspaces,
+            "dxspaces_url": dxspaces_url 
+
         }
     )

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -119,7 +119,7 @@
             <div class="card-body card-body-custom">
                 <a href="{{ dxspaces_url }}" class="btn btn-primary"
                 target="_blank" rel="noopener noreferrer">
-                    Access DXSpaces
+                    Access
                 </a>
             </div>
         </div>

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -109,6 +109,21 @@
             </div>
         </div>
         {% endif %}
+
+        <!-- DXSpaces -->
+        {% if use_dxspaces %}
+        <div class="card card-square shadow-sm mx-2 my-2">
+            <div class="card-header card-header-custom">
+                <h5 class="card-title-custom">DXSpaces</h5>
+            </div>
+            <div class="card-body card-body-custom">
+                <a href="{{ dxspaces_url }}" class="btn btn-primary"
+                target="_blank" rel="noopener noreferrer">
+                    Access DXSpaces
+                </a>
+            </div>
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR resolves #69 by integrating DXSpaces (data staging) into the dashboard interface, similar to the existing JupyterHub integration.

### Implemented features:
- New configuration flags `use_dxspaces` and `dxspaces_url` in `swagger_settings.py`.
- Context passed from backend to template includes DXSpaces configuration.
- Dashboard now conditionally displays a DXSpaces card, linking to the configured DXSpaces URL.