### PR TITLE
Update default metrics_endpoint and env_file path

### DIFF
--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -8,14 +8,14 @@ class Settings(BaseSettings):
     swagger_description: str = "This is the API documentation."
     swagger_version: str = "0.6.0"
     public: bool = True
-    metrics_endpoint: str = "http://fed-api:80/metrics/"
+    metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"
     use_dxspaces: bool = False
     dxspaces_url: str = "http://localhost:8001"
 
     model_config = {
-        "env_file": "./env_variables/.env_swagger",
+        "env_file": ".env",
         "extra": "allow",
     }
 


### PR DESCRIPTION
This PR updates the default metrics_endpoint in swagger_settings.py from http://fed-api/metrics/ to http://federation.ndp.utah.edu/metrics/ to reflect the correct endpoint for the federation setup. It also changes the env_file path from ./env_variables/.env_swagger to .env for consistency with the rest of the application configuration.

Closes #75.