### PR TITLE
Fix #77: Validate Required CKAN Fields Before Resource Creation

### DIFF
--- a/api/routes/register_routes/post_kafka.py
+++ b/api/routes/register_routes/post_kafka.py
@@ -1,3 +1,4 @@
+# api\routes\register_routes\post_kafka.py
 from fastapi import APIRouter, HTTPException, status, Depends, Query
 from typing import Dict, Any, Literal
 from api.services import kafka_services

--- a/api/routes/register_routes/post_kafka.py
+++ b/api/routes/register_routes/post_kafka.py
@@ -1,12 +1,12 @@
-# api/routes/register_routes/post_kafka.py
-# Code in English, PEP-8 lines <=79 chars
-
 from fastapi import APIRouter, HTTPException, status, Depends, Query
 from typing import Dict, Any, Literal
 from api.services import kafka_services
 from api.models.request_kafka_model import KafkaDataSourceRequest
 from api.services.keycloak_services.get_current_user import get_current_user
 from api.config import ckan_settings
+from api.services.validation_services.validate_preckan_fields import (
+    validate_preckan_fields,
+)
 
 router = APIRouter()
 
@@ -105,10 +105,6 @@ async def create_kafka_datasource(
     """
     Add a Kafka topic and its associated metadata to the system.
 
-    If ?server=pre_ckan, uses the pre-CKAN instance. If pre_ckan_enabled is
-    False or the URL lacks a valid scheme, returns a 400 error. Otherwise,
-    it defaults to local CKAN.
-
     Parameters
     ----------
     data : KafkaDataSourceRequest
@@ -136,6 +132,17 @@ async def create_kafka_datasource(
                     status_code=400,
                     detail="Pre-CKAN is disabled and cannot be used."
                 )
+
+            document = data.dict()
+            missing_fields = validate_preckan_fields(document)
+
+            if missing_fields:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Missing required fields for pre_ckan: "
+                           f"{missing_fields}"
+                )
+
             ckan_instance = ckan_settings.pre_ckan
         else:
             ckan_instance = ckan_settings.ckan

--- a/api/routes/register_routes/post_s3.py
+++ b/api/routes/register_routes/post_s3.py
@@ -1,11 +1,12 @@
-# api/routes/register_routes/post_s3.py
-
 from fastapi import APIRouter, HTTPException, status, Depends, Query
 from typing import Dict, Any, Literal
 from api.services.s3_services.add_s3 import add_s3
 from api.models.s3request_model import S3Request
 from api.services.keycloak_services.get_current_user import get_current_user
 from api.config import ckan_settings
+from api.services.validation_services.validate_preckan_fields import (
+    validate_preckan_fields,
+)
 
 router = APIRouter()
 
@@ -82,6 +83,17 @@ async def create_s3_resource(
                     status_code=400,
                     detail="Pre-CKAN is disabled and cannot be used."
                 )
+
+            document = data.dict()
+            missing_fields = validate_preckan_fields(document)
+
+            if missing_fields:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Missing required fields for pre_ckan: "
+                           f"{missing_fields}"
+                )
+
             ckan_instance = ckan_settings.pre_ckan
         else:
             ckan_instance = ckan_settings.ckan

--- a/api/routes/register_routes/post_url.py
+++ b/api/routes/register_routes/post_url.py
@@ -6,6 +6,10 @@ from api.services.url_services.add_url import add_url
 from api.models.urlrequest_model import URLRequest
 from api.services.keycloak_services.get_current_user import get_current_user
 from api.config import ckan_settings
+from api.services.validation_services.validate_preckan_fields import (
+    validate_preckan_fields,
+)
+
 
 router = APIRouter()
 
@@ -95,9 +99,20 @@ async def create_url_resource(
                     status_code=400,
                     detail="Pre-CKAN is disabled and cannot be used."
                 )
+            # Validate required fields for pre_ckan insertion
+            document = data.dict()
+            missing_fields = validate_preckan_fields(document)
+
+            if missing_fields:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Missing required fields for pre_ckan: {missing_fields}"
+                )
+
             ckan_instance = ckan_settings.pre_ckan
         else:
             ckan_instance = ckan_settings.ckan
+
 
         resource_id = add_url(
             resource_name=data.resource_name,

--- a/api/routes/register_routes/post_url.py
+++ b/api/routes/register_routes/post_url.py
@@ -106,13 +106,13 @@ async def create_url_resource(
             if missing_fields:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Missing required fields for pre_ckan: {missing_fields}"
+                    detail=("Missing required fields for "
+                            f"pre_ckan: {missing_fields}")
                 )
 
             ckan_instance = ckan_settings.pre_ckan
         else:
             ckan_instance = ckan_settings.ckan
-
 
         resource_id = add_url(
             resource_name=data.resource_name,

--- a/api/services/status_services/check_api_status.py
+++ b/api/services/status_services/check_api_status.py
@@ -53,7 +53,9 @@ def get_status():
     try:
         get_client_token()
         status_dict["keycloak_is_active"] = True
+        print("Keycloak is active")
     except Exception:
         status_dict["keycloak_is_active"] = False
+        print("Keycloak is not active")
 
     return status_dict

--- a/api/services/validation_services/validate_preckan_fields.py
+++ b/api/services/validation_services/validate_preckan_fields.py
@@ -1,0 +1,74 @@
+from typing import Dict, List
+
+
+REQUIRED_CKAN_FIELDS = [
+    'title',
+    'notes',
+    'tags',
+    'extras:uploadType',
+    'extras:dataType',
+    'extras:purpose',
+    'extras:publisherName',
+    'extras:publisherEmail',
+    'extras:creatorName',
+    'extras:creatorEmail',
+    'extras:pocName',
+    'extras:pocEmail',
+    'extras:license / extras:otherLicense',
+    'extras:issueDate',
+    'extras:lastUpdateDate',
+    'resource:name',
+    'resource:description',
+    'resource:mimetype',
+    'resource:status',
+]
+
+
+def validate_preckan_fields(document: Dict) -> List[str]:
+    """
+    Validate that a document has all required CKAN fields for insertion into preckan.
+
+    Args:
+        document (Dict): The document to validate.
+
+    Returns:
+        List[str]: A list of missing required fields. Empty if none are missing.
+    """
+    missing_fields = []
+
+    for field in REQUIRED_CKAN_FIELDS:
+        # Handle nested fields if necessary
+        if ':' in field:
+            prefix, subfield = field.split(':', 1)
+            if prefix not in document or subfield not in document[prefix]:
+                missing_fields.append(field)
+        else:
+            if field not in document:
+                missing_fields.append(field)
+
+    return missing_fields
+
+
+# Example of how to use this function inside a FastAPI route
+from fastapi import FastAPI, HTTPException
+from fastapi import Request
+
+app = FastAPI()
+
+
+@app.post("/insert-preckan/")
+async def insert_preckan(request: Request):
+    """
+    Endpoint to insert a document into preckan after validating required fields.
+    """
+    document = await request.json()
+    missing_fields = validate_preckan_fields(document)
+
+    if missing_fields:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required fields: {missing_fields}"
+        )
+
+    # Continue with insertion logic here
+    return {"message": "Document validated and ready for insertion"}

--- a/api/services/validation_services/validate_preckan_fields.py
+++ b/api/services/validation_services/validate_preckan_fields.py
@@ -27,13 +27,15 @@ REQUIRED_CKAN_FIELDS = [
 
 def validate_preckan_fields(document: Dict) -> List[str]:
     """
-    Validate that a document has all required CKAN fields for insertion into preckan.
+    Validate that a document has all required CKAN fields for insertion into
+    preckan.
 
     Args:
         document (Dict): The document to validate.
 
     Returns:
-        List[str]: A list of missing required fields. Empty if none are missing.
+        List[str]: A list of missing required fields.
+            Empty if none are missing.
     """
     missing_fields = []
 
@@ -48,28 +50,3 @@ def validate_preckan_fields(document: Dict) -> List[str]:
                 missing_fields.append(field)
 
     return missing_fields
-
-
-# Example of how to use this function inside a FastAPI route
-from fastapi import FastAPI, HTTPException
-from fastapi import Request
-
-app = FastAPI()
-
-
-@app.post("/insert-preckan/")
-async def insert_preckan(request: Request):
-    """
-    Endpoint to insert a document into preckan after validating required fields.
-    """
-    document = await request.json()
-    missing_fields = validate_preckan_fields(document)
-
-    if missing_fields:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Missing required fields: {missing_fields}"
-        )
-
-    # Continue with insertion logic here
-    return {"message": "Document validated and ready for insertion"}

--- a/api/services/validation_services/validate_preckan_fields.py
+++ b/api/services/validation_services/validate_preckan_fields.py
@@ -1,3 +1,4 @@
+# api\services\validation_services\validate_preckan_fields.py
 from typing import Dict, List
 
 

--- a/tests/test_create_kafka_datasource.py
+++ b/tests/test_create_kafka_datasource.py
@@ -199,6 +199,7 @@ def test_create_kafka_datasource_duplicate_error():
         # Clean up the override
         app.dependency_overrides.pop(get_current_user, None)
 
+
 def test_create_kafka_datasource_missing_preckan_fields():
     # Skip if the POST /kafka route does not exist
     if not route_exists("/kafka", "POST"):
@@ -221,8 +222,8 @@ def test_create_kafka_datasource_missing_preckan_fields():
     }
 
     with patch("api.config.ckan_settings.pre_ckan_enabled", True), \
-        patch("api.config.ckan_settings.pre_ckan_url", "mock_pre_ckan_url"), \
-        patch("api.config.ckan_settings.pre_ckan_api_key", "mock_api_key"):
+         patch("api.config.ckan_settings.pre_ckan_url", "mock_pre_ckan_url"), \
+         patch("api.config.ckan_settings.pre_ckan_api_key", "mock_api_key"):
 
         response = client.post("/kafka?server=pre_ckan", json=data)
 

--- a/tests/test_kafka_datasource_registration_and_search.py
+++ b/tests/test_kafka_datasource_registration_and_search.py
@@ -64,14 +64,16 @@ def test_kafka_datasource_registration_and_search():
     print("Status code:", status_code)
     print("Response JSON:", response_json)
 
-    # Skip the test if SSL certificate error is detected
+    # Skip the test if SSL or connection error is detected
+    detail = response_json.get("detail", "").lower()
     if (
         status_code == 400 and isinstance(response_json, dict)
-        and "certificate verify failed" in response_json.get("detail", "")
-    ):
+        and (
+            "certificate verify failed" in detail
+            or "connection refused" in detail
+            or "max retries exceeded" in detail)):
         pytest.skip(
-            "SSL certificate verification failed when connecting to "
-            "remote CKAN. "
+            "CKAN connection error when connecting to remote CKAN. "
             "This is an external issue and not related to the API itself."
         )
 


### PR DESCRIPTION
This PR implements strict validation of required CKAN fields when sending metadata to the `pre_ckan` server. It introduces a new utility function, `validate_preckan_fields()`, which inspects the incoming payload for all fields defined in the NDP Metadata Schema. Nested fields (e.g., `extras:uploadType`, `resource:name`) are supported via colon notation.


Closes: #77
