### PR TITLE
feat: Include swagger_version in system metrics payload

### DIFF
--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -89,6 +89,15 @@ async def record_system_metrics():
                 "services": services
             }
 
+            # Example logged payload:
+            # {
+            #     "public_ip": "1.2.3.4",
+            #     "cpu": "15%",
+            #     "memory": "65%",
+            #     "disk": "70%",
+            #     "version": "0.6.0",
+            #     "services": {...}
+            # }
             # Log metrics as JSON
             logger.info(json.dumps(metrics_payload))
 

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 async def record_system_metrics():
     """
     Periodically logs the system metrics:
-    Public IP, CPU, memory, and disk usage.
+    Public IP, CPU, memory, disk usage, and API version.
 
     Additionally, if public=True, posts the metrics JSON to metrics_endpoint.
     """

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -85,6 +85,7 @@ async def record_system_metrics():
                 "cpu": f"{cpu}%",
                 "memory": f"{mem}%",
                 "disk": f"{disk}%",
+                "version": swagger_settings.swagger_version,
                 "services": services
             }
 


### PR DESCRIPTION
Por supuesto Raúl. Aquí la tienes:

---

## Pull Request Title

```
feat: Include swagger_version in system metrics payload
```

## Pull Request Description

### Description

This PR resolves issue #79 by including the API version (`swagger_version`)
in the system metrics payload sent to the metrics endpoint.

### Changes Introduced

* Added `version` field to the `metrics_payload` in `metrics_task.py`.
* Updated the function docstring to document the new field.
* Included an example of the updated payload in the code comments.

### How to Test

1. Start the API with `public` set to `True` in your `.env` file.
2. Check the logs and verify that the `version` field appears in the JSON.
3. Ensure that the payload sent to `metrics_endpoint` includes the `version`.

### Example Payload

```json
{
  "public_ip": "1.2.3.4",
  "cpu": "15%",
  "memory": "65%",
  "disk": "70%",
  "version": "0.6.0",
  "services": { ... }
}
```

### Related Issue

Closes #79
