### PR TITLE
feat: allow custom file types in URLRequest model

### DIFF
--- a/api/services/url_services/add_url.py
+++ b/api/services/url_services/add_url.py
@@ -19,7 +19,7 @@ def add_url(
     extras=None,
     mapping=None,
     processing=None,
-    ckan_instance=None  # <-- New param
+    ckan_instance=None
 ):
     """
     Add a URL resource to CKAN.


### PR DESCRIPTION
- Replaced FileTypeEnum with a plain string to support custom file types
- Updated processing validation to apply only for known built-in types (CSV, JSON, etc.)
- Skipped validation for unknown/custom file types to improve flexibility