### PR TITLE
Add Organization Field to System Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,23 @@ The POP API periodically logs essential system metrics, including:
 - **CPU usage**
 - **Memory usage**
 - **Disk usage**
+- **Organization identification**
 
 Additionally, it provides information about currently enabled and connected external services such as Kafka, JupyterLab, and CKAN instances.
 
 ### How It Works
 
 Every 10 minutes (adjustable interval), the API logs these metrics in JSON format for easy integration with log-monitoring tools or further analysis.
+
+### Organization Configuration
+
+To identify which organization is running the POP installation, set the `ORGANIZATION` environment variable in your `.env` file:
+
+```env
+ORGANIZATION=University of Utah
+```
+
+If not configured, the system will use "Unknown Organization" as the default value.
 
 ### Example of Logged Metrics
 
@@ -77,6 +88,8 @@ The logs follow this structured JSON format:
   "cpu": "10%",
   "memory": "60%",
   "disk": "20%",
+  "version": "0.6.0",
+  "organization": "University of Utah",
   "services": {
     "jupyter": "https://jupyter.org/try-jupyter/lab/",
     "pre_ckan": "http://localhost:5000",
@@ -99,10 +112,12 @@ To enable or disable sending metrics externally, adjust the following in `env_va
 ```env
 PUBLIC=True
 METRICS_ENDPOINT=http://your-external-endpoint.com/metrics
+ORGANIZATION=University of Utah
 ```
 
 - Set `PUBLIC=True` to enable metrics forwarding.
 - Set the `METRICS_ENDPOINT` to your desired metrics collection endpoint.
+- Set `ORGANIZATION` to identify your institution in the metrics data.
 
 Ensure your external endpoint can accept POST requests with JSON payloads in the format described above.
 
@@ -110,6 +125,7 @@ Ensure your external endpoint can accept POST requests with JSON payloads in the
 
 - If metrics are not sent correctly, verify that your external endpoint is reachable from your API instance.
 - Check logs for error messages related to metrics collection or sending.
+- Verify that the `ORGANIZATION` field is properly configured if you need to identify your POP installation.
 
 ## Running Tests
 

--- a/api/config/swagger_settings.py
+++ b/api/config/swagger_settings.py
@@ -4,11 +4,17 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    """
+    Configuration settings for the API application.
+    
+    All settings can be overridden using environment variables.
+    """
     swagger_title: str = "API Documentation"
     swagger_description: str = "This is the API documentation."
     swagger_version: str = "0.6.0"
     public: bool = True
     metrics_endpoint: str = "https://federation.ndp.utah.edu/metrics/"
+    organization: str = "Unknown Organization"
     use_jupyterlab: bool = False
     jupyter_url: str = "https://jupyter.org/try-jupyter/lab/"
     use_dxspaces: bool = False

--- a/api/tasks/metrics_task.py
+++ b/api/tasks/metrics_task.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 async def record_system_metrics():
     """
     Periodically logs the system metrics:
-    Public IP, CPU, memory, disk usage, and API version.
+    Public IP, CPU, memory, disk usage, API version, and organization.
 
     Additionally, if public=True, posts the metrics JSON to metrics_endpoint.
     """
@@ -80,6 +80,7 @@ async def record_system_metrics():
                 "memory": f"{mem}%",
                 "disk": f"{disk}%",
                 "version": swagger_settings.swagger_version,
+                "organization": swagger_settings.organization,
                 "services": services
             }
 
@@ -90,6 +91,7 @@ async def record_system_metrics():
             #     "memory": "65%",
             #     "disk": "70%",
             #     "version": "0.6.0",
+            #     "organization": "University of Utah",
             #     "services": {...}
             # }
             # Log metrics as JSON

--- a/example.env
+++ b/example.env
@@ -73,6 +73,9 @@ SWAGGER_TITLE=
 # Description displayed in Swagger UI
 SWAGGER_DESCRIPTION=
 
+# Organization name for metrics identification (e.g., "University of Utah")
+ORGANIZATION=
+
 # ==============================================
 # External Service Integrations
 # ==============================================

--- a/tests/test_metrics_organization.py
+++ b/tests/test_metrics_organization.py
@@ -1,0 +1,134 @@
+import pytest
+import json
+import asyncio
+from unittest.mock import patch, AsyncMock, MagicMock
+from api.config.swagger_settings import swagger_settings
+
+
+def test_organization_field_exists_in_settings():
+    """Test that organization field exists in swagger settings."""
+    assert hasattr(swagger_settings, 'organization')
+    assert isinstance(swagger_settings.organization, str)
+
+
+def test_organization_default_value():
+    """Test that organization has the expected default value."""
+    from api.config.swagger_settings import Settings
+    
+    # Test without any environment variables
+    with patch.dict('os.environ', {}, clear=True):
+        test_settings = Settings()
+        assert test_settings.organization == "Unknown Organization"
+
+
+def test_organization_environment_variable():
+    """Test that organization can be set via ORGANIZATION env variable."""
+    from api.config.swagger_settings import Settings
+    
+    with patch.dict('os.environ', {'ORGANIZATION': 'Test University'}):
+        test_settings = Settings()
+        assert test_settings.organization == "Test University"
+
+
+@pytest.mark.asyncio
+async def test_metrics_payload_includes_organization():
+    """Test that organization field is included in metrics payload."""
+    from api.tasks.metrics_task import record_system_metrics
+    
+    test_organization = "University of Testing"
+    
+    with patch('api.services.status_services.get_public_ip') as mock_ip, \
+         patch('api.services.status_services.get_system_metrics') as mock_sys, \
+         patch.object(swagger_settings, 'organization', test_organization), \
+         patch.object(swagger_settings, 'public', False), \
+         patch('asyncio.sleep') as mock_sleep, \
+         patch('api.tasks.metrics_task.logger') as mock_logger:
+        
+        # Set up mock return values
+        mock_ip.return_value = "192.168.1.100"
+        mock_sys.return_value = (25.5, 60.2, 45.8)
+        mock_sleep.side_effect = asyncio.CancelledError()
+        
+        try:
+            await record_system_metrics()
+        except asyncio.CancelledError:
+            pass  # Expected due to mock_sleep
+        
+        # Verify logger.info was called with JSON containing organization
+        assert mock_logger.info.called
+        logged_json = mock_logger.info.call_args[0][0]
+        metrics_payload = json.loads(logged_json)
+        
+        assert "organization" in metrics_payload
+        assert metrics_payload["organization"] == test_organization
+
+
+@pytest.mark.asyncio
+async def test_organization_sent_to_metrics_endpoint():
+    """Test organization is sent to endpoint when public=True."""
+    from api.tasks.metrics_task import record_system_metrics
+    
+    test_organization = "Public University"
+    
+    with patch('api.services.status_services.get_public_ip') as mock_ip, \
+         patch('api.services.status_services.get_system_metrics') as mock_sys, \
+         patch.object(swagger_settings, 'organization', test_organization), \
+         patch.object(swagger_settings, 'public', True), \
+         patch('httpx.AsyncClient') as mock_client, \
+         patch('asyncio.sleep') as mock_sleep, \
+         patch('logging.getLogger'):
+        
+        mock_ip.return_value = "203.0.113.1"
+        mock_sys.return_value = (15.0, 45.0, 30.0)
+        mock_sleep.side_effect = asyncio.CancelledError()
+        
+        # Mock HTTP client
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_client.return_value.__aenter__.return_value = mock_client_instance
+        
+        try:
+            await record_system_metrics()
+        except asyncio.CancelledError:
+            pass
+        
+        # Verify POST request was made with organization in payload
+        assert mock_client_instance.post.called
+        post_call = mock_client_instance.post.call_args
+        posted_payload = post_call[1]['json']
+        
+        assert "organization" in posted_payload
+        assert posted_payload["organization"] == test_organization
+
+
+def test_metrics_payload_structure():
+    """Test that metrics payload has expected structure with organization."""
+    expected_fields = [
+        "public_ip",
+        "cpu",
+        "memory", 
+        "disk",
+        "version",
+        "organization",
+        "services"
+    ]
+    
+    # Simulate payload structure from metrics_task.py
+    sample_payload = {
+        "public_ip": "127.0.0.1",
+        "cpu": "25%",
+        "memory": "60%",
+        "disk": "45%", 
+        "version": swagger_settings.swagger_version,
+        "organization": swagger_settings.organization,
+        "services": {}
+    }
+    
+    for field in expected_fields:
+        assert field in sample_payload
+    
+    assert isinstance(sample_payload["organization"], str)
+    assert len(sample_payload["organization"]) > 0
+    


### PR DESCRIPTION
This PR adds a new `organization` field to the system metrics payload, allowing identification of which organization has a POP (Point of Presence) installation deployed.

## Changes Made

### ✨ Features
- **Configuration**: Added `organization` field to `swagger_settings.py` with default value "Unknown Organization"
- **Metrics**: Include organization field in metrics payload sent to logs and external endpoint
- **Environment Variable**: Support for `ORGANIZATION` environment variable configuration

### 🧪 Testing  
- Comprehensive test suite covering all organization functionality
- Tests for configuration, metrics payload, and external endpoint integration
- All tests passing ✅

### 📚 Documentation
- Updated `README.md` with organization configuration instructions
- Added `ORGANIZATION` field to `example.env` template
- Updated example JSON payload to show organization field

## Technical Details

### Files Modified
- `api/config/swagger_settings.py` - Added organization configuration
- `api/tasks/metrics_task.py` - Include organization in metrics payload  
- `tests/test_metrics_organization.py` - New comprehensive test suite
- `README.md` - Updated documentation
- `example.env` - Added organization configuration example

### Configuration
```env
# Set in .env file
ORGANIZATION=University of Utah
```

### Example Output
```json
{
  "public_ip": "1.2.3.4",
  "cpu": "15%", 
  "memory": "65%",
  "disk": "70%",
  "version": "0.6.0",
  "organization": "University of Utah",
  "services": {...}
}
```

## Testing
- All existing tests continue to pass
- New tests specifically cover organization functionality
- Tested both with and without environment variable configuration

## Breaking Changes
None. This is a backward-compatible addition with sensible defaults.

## Checklist
- [x] Code follows PEP-8 guidelines with 79 character line limit
- [x] All comments and docstrings in English
- [x] Comprehensive test coverage added
- [x] Documentation updated (README.md and example.env)
- [x] All tests passing
- [x] No breaking changes introduced
- [x] Environment variable support implemented

## Related Issues
Closes #83

## Review Notes
This feature enables better tracking and identification of POP installations across different organizations in the federation network. The implementation is minimal, well-tested, and maintains backward compatibility.